### PR TITLE
로그인 기능 구현의 머지 충돌로 인한 오류를 고친다

### DIFF
--- a/src/main/java/org/swyp/weddy/common/exception/ErrorCode.java
+++ b/src/main/java/org/swyp/weddy/common/exception/ErrorCode.java
@@ -2,6 +2,7 @@ package org.swyp.weddy.common.exception;
 
 public enum ErrorCode {
 
+    BAD_REQUEST("400", "잘못된 요청"),
     DUPLICATE_CHECKLIST("400", "사용자에게 할당된 체크리스트가 이미 존재합니다"),
     UNAUTHORIZED("401", "인증되지 않은 사용자"),
     NOT_EXISTS("404", "리소스가 존재하지 않음"),

--- a/src/main/resources/sql/schema.sql
+++ b/src/main/resources/sql/schema.sql
@@ -77,8 +77,4 @@ ALTER TABLE `small_category_item`
     ADD FOREIGN KEY (`status_id`) REFERENCES `small_category_item_status` (`id`);
 
 ALTER TABLE `small_category_item`
-<<<<<<< HEAD
     ADD FOREIGN KEY (`assignee_id`) REFERENCES `small_category_item_assignee` (`id`);
-=======
-    ADD FOREIGN KEY (`assignee_id`) REFERENCES `small_category_item_assignee` (`id`);
->>>>>>> main


### PR DESCRIPTION
로그인 구현 기능 머지 충돌하면서
- ErrorCode에서 빠진 코드와
- 스키마 파일에 잘못 들어간 문자열을

지웁니다