### PR TITLE
회원 아이디에 할당된 체크리스트를 가져올 수 있다

### DIFF
--- a/src/main/java/org/swyp/weddy/common/exception/ControllerAdvice.java
+++ b/src/main/java/org/swyp/weddy/common/exception/ControllerAdvice.java
@@ -3,6 +3,7 @@ package org.swyp.weddy.common.exception;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.swyp.weddy.domain.checklist.exception.ChecklistAlreadyAssignedException;
+import org.swyp.weddy.domain.checklist.exception.ChecklistNotExistsException;
 import org.swyp.weddy.domain.wiki.exception.WikiNotFoundException;
 
 @RestControllerAdvice
@@ -17,6 +18,12 @@ public class ControllerAdvice {
     protected ErrorResponse ChecklistAlreadyAssignedException(final ChecklistAlreadyAssignedException exception) {
         return new ErrorResponse(exception.getErrorCode());
     }
+
+    @ExceptionHandler(ChecklistNotExistsException.class)
+    protected ErrorResponse handleChecklistNotExistsException(final ChecklistNotExistsException exception) {
+        return new ErrorResponse(exception.getErrorCode());
+    }
+
 
     private static class ErrorResponse {
         private final String code;

--- a/src/main/java/org/swyp/weddy/common/exception/ControllerAdvice.java
+++ b/src/main/java/org/swyp/weddy/common/exception/ControllerAdvice.java
@@ -10,7 +10,12 @@ import org.swyp.weddy.domain.wiki.exception.WikiNotFoundException;
 public class ControllerAdvice {
 
     @ExceptionHandler(RuntimeException.class)
-    protected ErrorResponse handleBusinessException(final WikiNotFoundException exception) {
+    protected ErrorResponse handleBusinessException(final RuntimeException exception) {
+        return new ErrorResponse(ErrorCode.BAD_REQUEST);
+    }
+
+    @ExceptionHandler(WikiNotFoundException.class)
+    protected ErrorResponse handleWikiNotFoundException(final WikiNotFoundException exception) {
         return new ErrorResponse(exception.getErrorCode());
     }
 

--- a/src/main/java/org/swyp/weddy/common/exception/ControllerAdvice.java
+++ b/src/main/java/org/swyp/weddy/common/exception/ControllerAdvice.java
@@ -15,7 +15,7 @@ public class ControllerAdvice {
     }
 
     @ExceptionHandler(ChecklistAlreadyAssignedException.class)
-    protected ErrorResponse ChecklistAlreadyAssignedException(final ChecklistAlreadyAssignedException exception) {
+    protected ErrorResponse handleChecklistAlreadyAssignedException(final ChecklistAlreadyAssignedException exception) {
         return new ErrorResponse(exception.getErrorCode());
     }
 

--- a/src/main/java/org/swyp/weddy/domain/checklist/entity/Checklist.java
+++ b/src/main/java/org/swyp/weddy/domain/checklist/entity/Checklist.java
@@ -3,12 +3,11 @@ package org.swyp.weddy.domain.checklist.entity;
 import org.swyp.weddy.domain.checklist.service.dto.ChecklistDto;
 
 import java.sql.Timestamp;
-import java.util.Date;
 
 public class Checklist {
-    private Integer id;
-    private String memberId;
-    private Date dDay;
+    private Long id;
+    private Long memberId;
+    private Integer dDay;
     private Timestamp createdAt;
     private Timestamp updatedAt;
     private Boolean isDeleted;
@@ -16,7 +15,7 @@ public class Checklist {
     public Checklist() {
     }
 
-    public Checklist(Integer id, String memberId, Date dDay, Timestamp createdAt, Timestamp updatedAt, Boolean isDeleted) {
+    public Checklist(Long id, Long memberId, Integer dDay, Timestamp createdAt, Timestamp updatedAt, Boolean isDeleted) {
         this.id = id;
         this.memberId = memberId;
         this.dDay = dDay;
@@ -25,7 +24,7 @@ public class Checklist {
         this.isDeleted = isDeleted;
     }
 
-    public Checklist(String memberId, Date dDay, Timestamp createdAt, Timestamp updatedAt, Boolean isDeleted) {
+    public Checklist(Long memberId, Integer dDay, Timestamp createdAt, Timestamp updatedAt, Boolean isDeleted) {
         this.memberId = memberId;
         this.dDay = dDay;
         this.createdAt = createdAt;
@@ -35,7 +34,7 @@ public class Checklist {
 
     public static Checklist from(ChecklistDto dto) {
         return new Checklist(
-                dto.getMemberId(),
+                Long.valueOf(dto.getMemberId()),
                 null,
                 new Timestamp(System.currentTimeMillis()),
                 null,
@@ -43,15 +42,15 @@ public class Checklist {
         );
     }
 
-    public Integer getId() {
+    public Long getId() {
         return id;
     }
 
-    public String getMemberId() {
+    public Long getMemberId() {
         return memberId;
     }
 
-    public Date getdDay() {
+    public Integer getdDay() {
         return dDay;
     }
 }

--- a/src/main/java/org/swyp/weddy/domain/checklist/entity/Checklist.java
+++ b/src/main/java/org/swyp/weddy/domain/checklist/entity/Checklist.java
@@ -46,4 +46,12 @@ public class Checklist {
     public Integer getId() {
         return id;
     }
+
+    public String getMemberId() {
+        return memberId;
+    }
+
+    public Date getdDay() {
+        return dDay;
+    }
 }

--- a/src/main/java/org/swyp/weddy/domain/checklist/exception/ChecklistNotExistsException.java
+++ b/src/main/java/org/swyp/weddy/domain/checklist/exception/ChecklistNotExistsException.java
@@ -1,0 +1,17 @@
+package org.swyp.weddy.domain.checklist.exception;
+
+import org.swyp.weddy.common.exception.ErrorCode;
+
+public class ChecklistNotExistsException extends RuntimeException {
+
+    private final ErrorCode errorCode;
+
+    public ChecklistNotExistsException(ErrorCode errorCode) {
+        super(errorCode.getReason());
+        this.errorCode = errorCode;
+    }
+
+    public ErrorCode getErrorCode() {
+        return this.errorCode;
+    }
+}

--- a/src/main/java/org/swyp/weddy/domain/checklist/service/ChecklistService.java
+++ b/src/main/java/org/swyp/weddy/domain/checklist/service/ChecklistService.java
@@ -4,7 +4,7 @@ import org.swyp.weddy.domain.checklist.service.dto.ChecklistDto;
 import org.swyp.weddy.domain.checklist.web.response.ChecklistResponse;
 
 public interface ChecklistService {
-    int assignChecklist(ChecklistDto dto);
+    Long assignChecklist(ChecklistDto dto);
 
     boolean hasChecklist(ChecklistDto dto);
 

--- a/src/main/java/org/swyp/weddy/domain/checklist/service/ChecklistService.java
+++ b/src/main/java/org/swyp/weddy/domain/checklist/service/ChecklistService.java
@@ -3,7 +3,7 @@ package org.swyp.weddy.domain.checklist.service;
 import org.swyp.weddy.domain.checklist.service.dto.ChecklistDto;
 
 public interface ChecklistService {
-    int assignChecklist(ChecklistDto memberId);
+    int assignChecklist(ChecklistDto dto);
 
     boolean hasChecklist(ChecklistDto dto);
 }

--- a/src/main/java/org/swyp/weddy/domain/checklist/service/ChecklistService.java
+++ b/src/main/java/org/swyp/weddy/domain/checklist/service/ChecklistService.java
@@ -1,9 +1,12 @@
 package org.swyp.weddy.domain.checklist.service;
 
 import org.swyp.weddy.domain.checklist.service.dto.ChecklistDto;
+import org.swyp.weddy.domain.checklist.web.response.ChecklistResponse;
 
 public interface ChecklistService {
     int assignChecklist(ChecklistDto dto);
 
     boolean hasChecklist(ChecklistDto dto);
+
+    ChecklistResponse findChecklist(ChecklistDto dto);
 }

--- a/src/main/java/org/swyp/weddy/domain/checklist/service/ChecklistServiceImpl.java
+++ b/src/main/java/org/swyp/weddy/domain/checklist/service/ChecklistServiceImpl.java
@@ -7,6 +7,7 @@ import org.swyp.weddy.domain.checklist.dao.ChecklistMapper;
 import org.swyp.weddy.domain.checklist.entity.Checklist;
 import org.swyp.weddy.domain.checklist.exception.ChecklistAlreadyAssignedException;
 import org.swyp.weddy.domain.checklist.service.dto.ChecklistDto;
+import org.swyp.weddy.domain.checklist.web.response.ChecklistResponse;
 
 @Service
 public class ChecklistServiceImpl implements ChecklistService {
@@ -36,5 +37,10 @@ public class ChecklistServiceImpl implements ChecklistService {
         Checklist checklist = mapper.selectChecklistByMemberId(memberId);
 
         return checklist != null;
+    }
+
+    @Override
+    public ChecklistResponse findChecklist(ChecklistDto dto) {
+        return null;
     }
 }

--- a/src/main/java/org/swyp/weddy/domain/checklist/service/ChecklistServiceImpl.java
+++ b/src/main/java/org/swyp/weddy/domain/checklist/service/ChecklistServiceImpl.java
@@ -6,6 +6,7 @@ import org.swyp.weddy.common.exception.ErrorCode;
 import org.swyp.weddy.domain.checklist.dao.ChecklistMapper;
 import org.swyp.weddy.domain.checklist.entity.Checklist;
 import org.swyp.weddy.domain.checklist.exception.ChecklistAlreadyAssignedException;
+import org.swyp.weddy.domain.checklist.exception.ChecklistNotExistsException;
 import org.swyp.weddy.domain.checklist.service.dto.ChecklistDto;
 import org.swyp.weddy.domain.checklist.web.response.ChecklistResponse;
 
@@ -41,6 +42,11 @@ public class ChecklistServiceImpl implements ChecklistService {
 
     @Override
     public ChecklistResponse findChecklist(ChecklistDto dto) {
-        return null;
+        Long memberId = Long.valueOf(dto.getMemberId());
+        Checklist checklist = mapper.selectChecklistByMemberId(memberId);
+        if (checklist == null) {
+            throw new ChecklistNotExistsException(ErrorCode.NOT_EXISTS);
+        }
+        return ChecklistResponse.from(checklist);
     }
 }

--- a/src/main/java/org/swyp/weddy/domain/checklist/service/ChecklistServiceImpl.java
+++ b/src/main/java/org/swyp/weddy/domain/checklist/service/ChecklistServiceImpl.java
@@ -21,7 +21,7 @@ public class ChecklistServiceImpl implements ChecklistService {
 
     @Transactional
     @Override
-    public int assignChecklist(ChecklistDto dto) {
+    public Long assignChecklist(ChecklistDto dto) {
         if (hasChecklist(dto)) {
             throw new ChecklistAlreadyAssignedException(ErrorCode.DUPLICATE_CHECKLIST);
         }

--- a/src/main/java/org/swyp/weddy/domain/checklist/web/ChecklistController.java
+++ b/src/main/java/org/swyp/weddy/domain/checklist/web/ChecklistController.java
@@ -5,6 +5,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import org.swyp.weddy.domain.checklist.service.ChecklistService;
 import org.swyp.weddy.domain.checklist.service.dto.ChecklistDto;
+import org.swyp.weddy.domain.checklist.web.response.ChecklistResponse;
 
 import java.util.Map;
 
@@ -21,7 +22,7 @@ public class ChecklistController {
 
     @PostMapping
     public ResponseEntity<Void> createChecklist(@RequestBody Map<String, String> memberIdMap) {
-        int insertId = checklistService.assignChecklist(ChecklistDto.from(memberIdMap.get("memberId")));
+        Long insertId = checklistService.assignChecklist(ChecklistDto.from(memberIdMap.get("memberId")));
         log.warn("---------------------");
         log.warn("insertId: " + insertId);
 
@@ -29,6 +30,14 @@ public class ChecklistController {
     }
 
     @GetMapping
+    public ResponseEntity<ChecklistResponse> getChecklist(@RequestParam(name = "memberId") String memberId) {
+        ChecklistDto dto = ChecklistDto.from(memberId);
+        ChecklistResponse checklist = checklistService.findChecklist(dto);
+
+        return ResponseEntity.ok().body(checklist);
+    }
+
+    @GetMapping("/assigned")
     public ResponseEntity<Void> hasChecklist(@RequestParam(name = "memberId") String memberId) {
         ChecklistDto dto = ChecklistDto.from(memberId);
         boolean hasChecklist = checklistService.hasChecklist(dto);

--- a/src/main/java/org/swyp/weddy/domain/checklist/web/ChecklistController.java
+++ b/src/main/java/org/swyp/weddy/domain/checklist/web/ChecklistController.java
@@ -29,7 +29,7 @@ public class ChecklistController {
     }
 
     @GetMapping
-    public ResponseEntity<Void> getChecklist(@RequestParam(name = "memberId") String memberId) {
+    public ResponseEntity<Void> hasChecklist(@RequestParam(name = "memberId") String memberId) {
         ChecklistDto dto = ChecklistDto.from(memberId);
         boolean hasChecklist = checklistService.hasChecklist(dto);
         log.warn("---------------------");

--- a/src/main/java/org/swyp/weddy/domain/checklist/web/response/ChecklistResponse.java
+++ b/src/main/java/org/swyp/weddy/domain/checklist/web/response/ChecklistResponse.java
@@ -1,0 +1,4 @@
+package org.swyp.weddy.domain.checklist.web.response;
+
+public class ChecklistResponse {
+}

--- a/src/main/java/org/swyp/weddy/domain/checklist/web/response/ChecklistResponse.java
+++ b/src/main/java/org/swyp/weddy/domain/checklist/web/response/ChecklistResponse.java
@@ -2,14 +2,12 @@ package org.swyp.weddy.domain.checklist.web.response;
 
 import org.swyp.weddy.domain.checklist.entity.Checklist;
 
-import java.util.Date;
-
 public class ChecklistResponse {
-    private final Integer id;
+    private final Long id;
     private final String memberId;
-    private final Date dDay;
+    private final Integer dDay;
 
-    public ChecklistResponse(Integer id, String memberId, Date dDay) {
+    public ChecklistResponse(Long id, String memberId, Integer dDay) {
         this.id = id;
         this.memberId = memberId;
         this.dDay = dDay;
@@ -18,7 +16,7 @@ public class ChecklistResponse {
     public static ChecklistResponse from(Checklist checklist) {
         return new ChecklistResponse(
                 checklist.getId(),
-                checklist.getMemberId(),
+                String.valueOf(checklist.getMemberId()),
                 checklist.getdDay()
         );
     }

--- a/src/main/java/org/swyp/weddy/domain/checklist/web/response/ChecklistResponse.java
+++ b/src/main/java/org/swyp/weddy/domain/checklist/web/response/ChecklistResponse.java
@@ -20,4 +20,16 @@ public class ChecklistResponse {
                 checklist.getdDay()
         );
     }
+
+    public Long getId() {
+        return id;
+    }
+
+    public String getMemberId() {
+        return memberId;
+    }
+
+    public Integer getdDay() {
+        return dDay;
+    }
 }

--- a/src/main/java/org/swyp/weddy/domain/checklist/web/response/ChecklistResponse.java
+++ b/src/main/java/org/swyp/weddy/domain/checklist/web/response/ChecklistResponse.java
@@ -1,4 +1,25 @@
 package org.swyp.weddy.domain.checklist.web.response;
 
+import org.swyp.weddy.domain.checklist.entity.Checklist;
+
+import java.util.Date;
+
 public class ChecklistResponse {
+    private final Integer id;
+    private final String memberId;
+    private final Date dDay;
+
+    public ChecklistResponse(Integer id, String memberId, Date dDay) {
+        this.id = id;
+        this.memberId = memberId;
+        this.dDay = dDay;
+    }
+
+    public static ChecklistResponse from(Checklist checklist) {
+        return new ChecklistResponse(
+                checklist.getId(),
+                checklist.getMemberId(),
+                checklist.getdDay()
+        );
+    }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -18,6 +18,9 @@ spring:
 
 mybatis:
   mapper-locations: classpath:mapper/*Mapper.xml
+  configuration:
+    log-impl: org.apache.ibatis.logging.slf4j.Slf4jImpl
+    map-underscore-to-camel-case: true
 
 logging:
   level:

--- a/src/main/resources/sql/data.sql
+++ b/src/main/resources/sql/data.sql
@@ -7,6 +7,6 @@ insert into `member` (`email`, `name`, `profile_image_url`, `created_at`, `updat
 values ('y@a.com', 'tester2', 'url', current_timestamp, null, 0);
 
 insert into `checklist` (`member_id`, `d_day`, `created_at`, `updated_at`, `is_deleted`)
-values (1, null, current_timestamp, null, 0);
+values (1, 100, current_timestamp, null, 0);
 insert into `checklist` (`member_id`, `d_day`, `created_at`, `updated_at`, `is_deleted`)
 values (2, null, current_timestamp, null, 0);

--- a/src/test/java/org/swyp/weddy/domain/checklist/service/ChecklistServiceTest.java
+++ b/src/test/java/org/swyp/weddy/domain/checklist/service/ChecklistServiceTest.java
@@ -65,6 +65,7 @@ class ChecklistServiceTest {
         String memberId = "1";
         ChecklistDto dto = ChecklistDto.from(memberId);
         ChecklistService service = new FakeChecklistService(new FakeChecklistMapper());
+        service.assignChecklist(dto);
 
         ChecklistResponse checklistResponse = service.findChecklist(dto);
         Assertions.assertNotNull(checklistResponse);
@@ -109,11 +110,13 @@ class ChecklistServiceTest {
         @Override
         public ChecklistResponse findChecklist(ChecklistDto dto) {
             Long memberId = Long.valueOf(dto.getMemberId());
-            if (memberId == 1L) {
-                return ChecklistResponse.from(Checklist.from(dto));
+            Checklist checklist = mapper.selectChecklistByMemberId(memberId);
+
+            if (checklist == null) {
+                throw new ChecklistNotExistsException(ErrorCode.NOT_EXISTS);
             }
 
-            throw new ChecklistNotExistsException(ErrorCode.NOT_EXISTS);
+            return ChecklistResponse.from(Checklist.from(dto));
         }
     }
 

--- a/src/test/java/org/swyp/weddy/domain/checklist/service/ChecklistServiceTest.java
+++ b/src/test/java/org/swyp/weddy/domain/checklist/service/ChecklistServiceTest.java
@@ -92,12 +92,12 @@ class ChecklistServiceTest {
         }
 
         @Override
-        public int assignChecklist(ChecklistDto dto) {
+        public Long assignChecklist(ChecklistDto dto) {
             if (hasChecklist(dto)) {
                 throw new ChecklistAlreadyAssignedException(ErrorCode.BAD_REQUEST);
             }
 
-            return mapper.insertChecklist(null);
+            return Long.valueOf(mapper.insertChecklist(null));
         }
 
         @Override

--- a/src/test/java/org/swyp/weddy/domain/checklist/service/ChecklistServiceTest.java
+++ b/src/test/java/org/swyp/weddy/domain/checklist/service/ChecklistServiceTest.java
@@ -8,6 +8,7 @@ import org.swyp.weddy.domain.checklist.dao.ChecklistMapper;
 import org.swyp.weddy.domain.checklist.entity.Checklist;
 import org.swyp.weddy.domain.checklist.exception.ChecklistAlreadyAssignedException;
 import org.swyp.weddy.domain.checklist.service.dto.ChecklistDto;
+import org.swyp.weddy.domain.checklist.web.response.ChecklistResponse;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -57,6 +58,17 @@ class ChecklistServiceTest {
         assertThrows(NumberFormatException.class, () -> Long.valueOf(sLong2));
     }
 
+    @DisplayName("회원 아이디에 할당된 체크리스트를 가져올 수 있다")
+    @Test
+    public void find_checklist_by_id() {
+        String memberId = "1";
+        ChecklistDto dto = ChecklistDto.from(memberId);
+        ChecklistService service = new FakeChecklistService(new FakeChecklistMapper());
+
+        ChecklistResponse checklistResponse = service.findChecklist(dto);
+        Assertions.assertNotNull(checklistResponse);
+    }
+
     private static class FakeChecklistService implements ChecklistService {
         private final ChecklistMapper mapper;
 
@@ -78,6 +90,11 @@ class ChecklistServiceTest {
             Long memberId = Long.valueOf(dto.getMemberId());
             Checklist checklist = mapper.selectChecklistByMemberId(memberId);
             return checklist != null;
+        }
+
+        @Override
+        public ChecklistResponse findChecklist(ChecklistDto dto) {
+            return new ChecklistResponse();
         }
     }
 


### PR DESCRIPTION
- 회원 아이디로 체크리스트를 가져오는 서비스 로직을 구현합니다.
- 구현 도중 발생한 오류를 해결합니다.
  - 체크리스트 가져오는 쿼리 결과를 객체에 연결 시 발생하는 오류
  - 응답 객체를 직렬화 시 발생하는 오류
- 예외 처리기 로직을 정리했습니다.
  - ControllerAdvice에 등록되지 않은 경우 기본 예외 정보로 json을 만들어 클라이언트로 전달하도록 바꿨습니다.