### PR TITLE
대분류 CRUD를 구현한다

### DIFF
--- a/req.http
+++ b/req.http
@@ -28,3 +28,12 @@ GET http://localhost:8080/checklist?memberId=3
 
 ###
 GET http://localhost:8080/checklist/large-cat-item?memberId=1&id=1
+
+###
+POST http://localhost:8080/checklist/large-cat-item
+Content-Type: application/json
+
+{
+  "memberId": "1",
+  "title": "test2"
+}

--- a/req.http
+++ b/req.http
@@ -27,7 +27,7 @@ GET http://localhost:8080/checklist?memberId=1
 GET http://localhost:8080/checklist?memberId=3
 
 ###
-GET http://localhost:8080/checklist/large-cat-item?memberId=1&id=1
+GET http://localhost:8080/checklist/large-cat-item/1?memberId=1
 
 ###
 POST http://localhost:8080/checklist/large-cat-item

--- a/req.http
+++ b/req.http
@@ -30,6 +30,9 @@ GET http://localhost:8080/checklist?memberId=3
 GET http://localhost:8080/checklist/large-cat-item/1?memberId=1
 
 ###
+GET http://localhost:8080/checklist/large-cat-item?memberId=1
+
+###
 POST http://localhost:8080/checklist/large-cat-item
 Content-Type: application/json
 

--- a/req.http
+++ b/req.http
@@ -25,3 +25,6 @@ GET http://localhost:8080/checklist?memberId=1
 
 ###
 GET http://localhost:8080/checklist?memberId=3
+
+###
+GET http://localhost:8080/checklist/large-cat-item?memberId=1&id=1

--- a/req.http
+++ b/req.http
@@ -47,3 +47,12 @@ Content-Type: application/json
   "id": "1",
   "editedTitle": "test_revised"
 }
+
+###
+PATCH http://localhost:8080/checklist/large-cat-item/delete
+Content-Type: application/json
+
+{
+  "memberId": "1",
+  "id": "1"
+}

--- a/req.http
+++ b/req.http
@@ -37,3 +37,13 @@ Content-Type: application/json
   "memberId": "1",
   "title": "test2"
 }
+
+###
+PATCH http://localhost:8080/checklist/large-cat-item
+Content-Type: application/json
+
+{
+  "memberId": "1",
+  "id": "1",
+  "editedTitle": "test_revised"
+}

--- a/src/main/java/org/swyp/weddy/common/exception/ControllerAdvice.java
+++ b/src/main/java/org/swyp/weddy/common/exception/ControllerAdvice.java
@@ -4,6 +4,7 @@ import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.swyp.weddy.domain.checklist.exception.ChecklistAlreadyAssignedException;
 import org.swyp.weddy.domain.checklist.exception.ChecklistNotExistsException;
+import org.swyp.weddy.domain.checklist.exception.LargeCatItemNotExistsException;
 import org.swyp.weddy.domain.wiki.exception.WikiNotFoundException;
 
 @RestControllerAdvice
@@ -28,6 +29,12 @@ public class ControllerAdvice {
     protected ErrorResponse handleChecklistNotExistsException(final ChecklistNotExistsException exception) {
         return new ErrorResponse(exception.getErrorCode());
     }
+
+    @ExceptionHandler(LargeCatItemNotExistsException.class)
+    protected ErrorResponse handleLargeCatItemNotExistsException(final LargeCatItemNotExistsException exception) {
+        return new ErrorResponse(exception.getErrorCode());
+    }
+
 
 
     private static class ErrorResponse {

--- a/src/main/java/org/swyp/weddy/domain/checklist/dao/LargeCatMapper.java
+++ b/src/main/java/org/swyp/weddy/domain/checklist/dao/LargeCatMapper.java
@@ -7,4 +7,6 @@ import org.swyp.weddy.domain.checklist.entity.LargeCatItem;
 @Mapper
 public interface LargeCatMapper {
     LargeCatItem selectItem(@Param("checklistId") Long checkListId, @Param("id") Long id);
+
+    Long insertItem(LargeCatItem item);
 }

--- a/src/main/java/org/swyp/weddy/domain/checklist/dao/LargeCatMapper.java
+++ b/src/main/java/org/swyp/weddy/domain/checklist/dao/LargeCatMapper.java
@@ -6,7 +6,7 @@ import org.swyp.weddy.domain.checklist.entity.LargeCatItem;
 
 @Mapper
 public interface LargeCatMapper {
-    LargeCatItem selectItem(@Param("checklistId") Long checkListId, @Param("id") Long id);
+    LargeCatItem selectItem(@Param("checklistId") Long checklistId, @Param("id") Long id);
 
     Long insertItem(LargeCatItem item);
 

--- a/src/main/java/org/swyp/weddy/domain/checklist/dao/LargeCatMapper.java
+++ b/src/main/java/org/swyp/weddy/domain/checklist/dao/LargeCatMapper.java
@@ -1,9 +1,10 @@
 package org.swyp.weddy.domain.checklist.dao;
 
 import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Param;
 import org.swyp.weddy.domain.checklist.entity.LargeCatItem;
 
 @Mapper
 public interface LargeCatMapper {
-    LargeCatItem selectItem(Long checkListId, Long id);
+    LargeCatItem selectItem(@Param("checkListId") Long checkListId, @Param("id") Long id);
 }

--- a/src/main/java/org/swyp/weddy/domain/checklist/dao/LargeCatMapper.java
+++ b/src/main/java/org/swyp/weddy/domain/checklist/dao/LargeCatMapper.java
@@ -4,9 +4,13 @@ import org.apache.ibatis.annotations.Mapper;
 import org.apache.ibatis.annotations.Param;
 import org.swyp.weddy.domain.checklist.entity.LargeCatItem;
 
+import java.util.List;
+
 @Mapper
 public interface LargeCatMapper {
     LargeCatItem selectItem(@Param("checklistId") Long checklistId, @Param("id") Long id);
+
+    List<LargeCatItem> selectAllItems(Long checklistId);
 
     Long insertItem(LargeCatItem item);
 

--- a/src/main/java/org/swyp/weddy/domain/checklist/dao/LargeCatMapper.java
+++ b/src/main/java/org/swyp/weddy/domain/checklist/dao/LargeCatMapper.java
@@ -6,5 +6,5 @@ import org.swyp.weddy.domain.checklist.entity.LargeCatItem;
 
 @Mapper
 public interface LargeCatMapper {
-    LargeCatItem selectItem(@Param("checkListId") Long checkListId, @Param("id") Long id);
+    LargeCatItem selectItem(@Param("checklistId") Long checkListId, @Param("id") Long id);
 }

--- a/src/main/java/org/swyp/weddy/domain/checklist/dao/LargeCatMapper.java
+++ b/src/main/java/org/swyp/weddy/domain/checklist/dao/LargeCatMapper.java
@@ -11,4 +11,6 @@ public interface LargeCatMapper {
     Long insertItem(LargeCatItem item);
 
     Long updateItem(LargeCatItem item);
+
+    Long deleteItem(LargeCatItem item);
 }

--- a/src/main/java/org/swyp/weddy/domain/checklist/dao/LargeCatMapper.java
+++ b/src/main/java/org/swyp/weddy/domain/checklist/dao/LargeCatMapper.java
@@ -1,0 +1,9 @@
+package org.swyp.weddy.domain.checklist.dao;
+
+import org.apache.ibatis.annotations.Mapper;
+import org.swyp.weddy.domain.checklist.entity.LargeCatItem;
+
+@Mapper
+public interface LargeCatMapper {
+    LargeCatItem selectItem(Long checkListId, Long id);
+}

--- a/src/main/java/org/swyp/weddy/domain/checklist/dao/LargeCatMapper.java
+++ b/src/main/java/org/swyp/weddy/domain/checklist/dao/LargeCatMapper.java
@@ -9,4 +9,6 @@ public interface LargeCatMapper {
     LargeCatItem selectItem(@Param("checklistId") Long checkListId, @Param("id") Long id);
 
     Long insertItem(LargeCatItem item);
+
+    Long updateItem(LargeCatItem item);
 }

--- a/src/main/java/org/swyp/weddy/domain/checklist/entity/LargeCatItem.java
+++ b/src/main/java/org/swyp/weddy/domain/checklist/entity/LargeCatItem.java
@@ -1,6 +1,7 @@
 package org.swyp.weddy.domain.checklist.entity;
 
 import org.swyp.weddy.domain.checklist.service.dto.LargeCatItemAssignDto;
+import org.swyp.weddy.domain.checklist.service.dto.LargeCatItemEditDto;
 
 import java.sql.Timestamp;
 
@@ -43,6 +44,17 @@ public class LargeCatItem {
         );
     }
 
+    public static LargeCatItem of(LargeCatItem itemBeforeEdit, LargeCatItemEditDto dto) {
+        return new LargeCatItem(
+                dto.getId(),
+                dto.getChecklistId(),
+                dto.getNewTitle(),
+                itemBeforeEdit.getCreatedAt(),
+                new Timestamp(System.currentTimeMillis()),
+                itemBeforeEdit.getIsDeleted()
+        );
+    }
+
     public Long getId() {
         return id;
     }
@@ -53,5 +65,13 @@ public class LargeCatItem {
 
     public String getTitle() {
         return title;
+    }
+
+    public Timestamp getCreatedAt() {
+        return createdAt;
+    }
+
+    public Boolean getIsDeleted() {
+        return isDeleted;
     }
 }

--- a/src/main/java/org/swyp/weddy/domain/checklist/entity/LargeCatItem.java
+++ b/src/main/java/org/swyp/weddy/domain/checklist/entity/LargeCatItem.java
@@ -1,5 +1,7 @@
 package org.swyp.weddy.domain.checklist.entity;
 
+import org.swyp.weddy.domain.checklist.service.dto.LargeCatItemAssignDto;
+
 import java.sql.Timestamp;
 
 public class LargeCatItem {
@@ -21,6 +23,10 @@ public class LargeCatItem {
         this.createdAt = createdAt;
         this.updatedAt = updatedAt;
         this.isDeleted = isDeleted;
+    }
+
+    public static LargeCatItem from(LargeCatItemAssignDto dto) {
+        return null;
     }
 
     public Long getId() {

--- a/src/main/java/org/swyp/weddy/domain/checklist/entity/LargeCatItem.java
+++ b/src/main/java/org/swyp/weddy/domain/checklist/entity/LargeCatItem.java
@@ -6,21 +6,21 @@ public class LargeCatItem {
     private Long id;
     private Long checklistId;
     private String title;
-    private Timestamp created_at;
-    private Timestamp updated_at;
-    private Boolean is_deleted;
+    private Timestamp createdAt;
+    private Timestamp updatedAt;
+    private Boolean isDeleted;
 
 
     public LargeCatItem() {
     }
 
-    public LargeCatItem(Long id, Long checklistId, String title, Timestamp created_at, Timestamp updated_at, Boolean is_deleted) {
+    public LargeCatItem(Long id, Long checklistId, String title, Timestamp createdAt, Timestamp updatedAt, Boolean isDeleted) {
         this.id = id;
         this.checklistId = checklistId;
         this.title = title;
-        this.created_at = created_at;
-        this.updated_at = updated_at;
-        this.is_deleted = is_deleted;
+        this.createdAt = createdAt;
+        this.updatedAt = updatedAt;
+        this.isDeleted = isDeleted;
     }
 
     public Long getId() {

--- a/src/main/java/org/swyp/weddy/domain/checklist/entity/LargeCatItem.java
+++ b/src/main/java/org/swyp/weddy/domain/checklist/entity/LargeCatItem.java
@@ -1,6 +1,7 @@
 package org.swyp.weddy.domain.checklist.entity;
 
 import org.swyp.weddy.domain.checklist.service.dto.LargeCatItemAssignDto;
+import org.swyp.weddy.domain.checklist.service.dto.LargeCatItemDeleteDto;
 import org.swyp.weddy.domain.checklist.service.dto.LargeCatItemEditDto;
 
 import java.sql.Timestamp;
@@ -55,6 +56,17 @@ public class LargeCatItem {
         );
     }
 
+    public static LargeCatItem ofDelete(LargeCatItem itemBeforeDelete, LargeCatItemDeleteDto dto) {
+        return new LargeCatItem(
+                dto.getId(),
+                dto.getChecklistId(),
+                itemBeforeDelete.getTitle(),
+                itemBeforeDelete.getCreatedAt(),
+                itemBeforeDelete.getUpdatedAt(),
+                Boolean.TRUE
+        );
+    }
+
     public Long getId() {
         return id;
     }
@@ -69,6 +81,10 @@ public class LargeCatItem {
 
     public Timestamp getCreatedAt() {
         return createdAt;
+    }
+
+    public Timestamp getUpdatedAt() {
+        return updatedAt;
     }
 
     public Boolean getIsDeleted() {

--- a/src/main/java/org/swyp/weddy/domain/checklist/entity/LargeCatItem.java
+++ b/src/main/java/org/swyp/weddy/domain/checklist/entity/LargeCatItem.java
@@ -1,0 +1,4 @@
+package org.swyp.weddy.domain.checklist.entity;
+
+public class LargeCatItem {
+}

--- a/src/main/java/org/swyp/weddy/domain/checklist/entity/LargeCatItem.java
+++ b/src/main/java/org/swyp/weddy/domain/checklist/entity/LargeCatItem.java
@@ -45,7 +45,7 @@ public class LargeCatItem {
         );
     }
 
-    public static LargeCatItem of(LargeCatItem itemBeforeEdit, LargeCatItemEditDto dto) {
+    public static LargeCatItem ofEdit(LargeCatItem itemBeforeEdit, LargeCatItemEditDto dto) {
         return new LargeCatItem(
                 dto.getId(),
                 dto.getChecklistId(),

--- a/src/main/java/org/swyp/weddy/domain/checklist/entity/LargeCatItem.java
+++ b/src/main/java/org/swyp/weddy/domain/checklist/entity/LargeCatItem.java
@@ -1,4 +1,37 @@
 package org.swyp.weddy.domain.checklist.entity;
 
+import java.sql.Timestamp;
+
 public class LargeCatItem {
+    private Long id;
+    private Long checklistId;
+    private String title;
+    private Timestamp created_at;
+    private Timestamp updated_at;
+    private Boolean is_deleted;
+
+
+    public LargeCatItem() {
+    }
+
+    public LargeCatItem(Long id, Long checklistId, String title, Timestamp created_at, Timestamp updated_at, Boolean is_deleted) {
+        this.id = id;
+        this.checklistId = checklistId;
+        this.title = title;
+        this.created_at = created_at;
+        this.updated_at = updated_at;
+        this.is_deleted = is_deleted;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public Long getChecklistId() {
+        return checklistId;
+    }
+
+    public String getTitle() {
+        return title;
+    }
 }

--- a/src/main/java/org/swyp/weddy/domain/checklist/entity/LargeCatItem.java
+++ b/src/main/java/org/swyp/weddy/domain/checklist/entity/LargeCatItem.java
@@ -25,8 +25,22 @@ public class LargeCatItem {
         this.isDeleted = isDeleted;
     }
 
+    public LargeCatItem(Long checklistId, String title, Timestamp createdAt, Timestamp updatedAt, Boolean isDeleted) {
+        this.checklistId = checklistId;
+        this.title = title;
+        this.createdAt = createdAt;
+        this.updatedAt = updatedAt;
+        this.isDeleted = isDeleted;
+    }
+
     public static LargeCatItem from(LargeCatItemAssignDto dto) {
-        return null;
+        return new LargeCatItem(
+                dto.getChecklistId(),
+                dto.getTitle(),
+                new Timestamp(System.currentTimeMillis()),
+                null,
+                Boolean.FALSE
+        );
     }
 
     public Long getId() {

--- a/src/main/java/org/swyp/weddy/domain/checklist/exception/LargeCatItemNotExistsException.java
+++ b/src/main/java/org/swyp/weddy/domain/checklist/exception/LargeCatItemNotExistsException.java
@@ -1,0 +1,17 @@
+package org.swyp.weddy.domain.checklist.exception;
+
+import org.swyp.weddy.common.exception.ErrorCode;
+
+public class LargeCatItemNotExistsException extends RuntimeException {
+
+    private final ErrorCode errorCode;
+
+    public LargeCatItemNotExistsException(ErrorCode errorCode) {
+        super(errorCode.getReason());
+        this.errorCode = errorCode;
+    }
+
+    public ErrorCode getErrorCode() {
+        return this.errorCode;
+    }
+}

--- a/src/main/java/org/swyp/weddy/domain/checklist/service/LargeCatService.java
+++ b/src/main/java/org/swyp/weddy/domain/checklist/service/LargeCatService.java
@@ -5,6 +5,8 @@ import org.swyp.weddy.domain.checklist.service.dto.LargeCatItemDeleteDto;
 import org.swyp.weddy.domain.checklist.service.dto.LargeCatItemEditDto;
 import org.swyp.weddy.domain.checklist.web.response.LargeCatItemResponse;
 
+import java.util.List;
+
 public interface LargeCatService {
     LargeCatItemResponse findItem(Long checklistId, Long id);
 
@@ -15,4 +17,6 @@ public interface LargeCatService {
     Long editItem(LargeCatItemEditDto dto);
 
     Long deleteItem(LargeCatItemDeleteDto dto);
+
+    List<LargeCatItemResponse> findAllItems(Long checklistId);
 }

--- a/src/main/java/org/swyp/weddy/domain/checklist/service/LargeCatService.java
+++ b/src/main/java/org/swyp/weddy/domain/checklist/service/LargeCatService.java
@@ -7,5 +7,7 @@ import org.swyp.weddy.domain.checklist.web.response.LargeCatItemResponse;
 public interface LargeCatService {
     LargeCatItemResponse findItem(Long checklistId, Long id);
 
+    LargeCatItemResponse findItemWithSmallItems(Long checklistId, Long id);
+
     Long addItem(LargeCatItemAssignDto dto);
 }

--- a/src/main/java/org/swyp/weddy/domain/checklist/service/LargeCatService.java
+++ b/src/main/java/org/swyp/weddy/domain/checklist/service/LargeCatService.java
@@ -1,7 +1,11 @@
 package org.swyp.weddy.domain.checklist.service;
 
+import org.swyp.weddy.domain.checklist.service.dto.LargeCatItemAssignDto;
+
 import org.swyp.weddy.domain.checklist.web.response.LargeCatItemResponse;
 
 public interface LargeCatService {
     LargeCatItemResponse findItem(Long checklistId, Long id);
+
+    Long addItem(LargeCatItemAssignDto dto);
 }

--- a/src/main/java/org/swyp/weddy/domain/checklist/service/LargeCatService.java
+++ b/src/main/java/org/swyp/weddy/domain/checklist/service/LargeCatService.java
@@ -1,0 +1,7 @@
+package org.swyp.weddy.domain.checklist.service;
+
+import org.swyp.weddy.domain.checklist.web.response.LargeCatItemResponse;
+
+public interface LargeCatService {
+    LargeCatItemResponse findItem(Long memberId, Long id);
+}

--- a/src/main/java/org/swyp/weddy/domain/checklist/service/LargeCatService.java
+++ b/src/main/java/org/swyp/weddy/domain/checklist/service/LargeCatService.java
@@ -18,5 +18,7 @@ public interface LargeCatService {
 
     Long deleteItem(LargeCatItemDeleteDto dto);
 
+    Long deleteItemWithSmallItems(LargeCatItemDeleteDto dto);
+
     List<LargeCatItemResponse> findAllItems(Long checklistId);
 }

--- a/src/main/java/org/swyp/weddy/domain/checklist/service/LargeCatService.java
+++ b/src/main/java/org/swyp/weddy/domain/checklist/service/LargeCatService.java
@@ -1,6 +1,7 @@
 package org.swyp.weddy.domain.checklist.service;
 
 import org.swyp.weddy.domain.checklist.service.dto.LargeCatItemAssignDto;
+import org.swyp.weddy.domain.checklist.service.dto.LargeCatItemDeleteDto;
 import org.swyp.weddy.domain.checklist.service.dto.LargeCatItemEditDto;
 import org.swyp.weddy.domain.checklist.web.response.LargeCatItemResponse;
 
@@ -12,4 +13,6 @@ public interface LargeCatService {
     Long addItem(LargeCatItemAssignDto dto);
 
     Long editItem(LargeCatItemEditDto dto);
+
+    Long deleteItem(LargeCatItemDeleteDto dto);
 }

--- a/src/main/java/org/swyp/weddy/domain/checklist/service/LargeCatService.java
+++ b/src/main/java/org/swyp/weddy/domain/checklist/service/LargeCatService.java
@@ -1,7 +1,7 @@
 package org.swyp.weddy.domain.checklist.service;
 
 import org.swyp.weddy.domain.checklist.service.dto.LargeCatItemAssignDto;
-
+import org.swyp.weddy.domain.checklist.service.dto.LargeCatItemEditDto;
 import org.swyp.weddy.domain.checklist.web.response.LargeCatItemResponse;
 
 public interface LargeCatService {
@@ -10,4 +10,6 @@ public interface LargeCatService {
     LargeCatItemResponse findItemWithSmallItems(Long checklistId, Long id);
 
     Long addItem(LargeCatItemAssignDto dto);
+
+    Long editItem(LargeCatItemEditDto dto);
 }

--- a/src/main/java/org/swyp/weddy/domain/checklist/service/LargeCatService.java
+++ b/src/main/java/org/swyp/weddy/domain/checklist/service/LargeCatService.java
@@ -3,5 +3,5 @@ package org.swyp.weddy.domain.checklist.service;
 import org.swyp.weddy.domain.checklist.web.response.LargeCatItemResponse;
 
 public interface LargeCatService {
-    LargeCatItemResponse findItem(Long memberId, Long id);
+    LargeCatItemResponse findItem(Long checklistId, Long id);
 }

--- a/src/main/java/org/swyp/weddy/domain/checklist/service/LargeCatServiceImpl.java
+++ b/src/main/java/org/swyp/weddy/domain/checklist/service/LargeCatServiceImpl.java
@@ -40,11 +40,12 @@ public class LargeCatServiceImpl implements LargeCatService {
     @Override
     public LargeCatItemResponse findItemWithSmallItems(Long checklistId, Long id) {
         LargeCatItem largeCatItem = mapper.selectItem(checklistId, id);
-        List<SmallCatItemPreviewResponse> itemPreviews = smallCatService.findItemPreviews(checklistId, id);
 
         if (largeCatItem == null) {
             throw new LargeCatItemNotExistsException(ErrorCode.NOT_EXISTS);
         }
+
+        List<SmallCatItemPreviewResponse> itemPreviews = smallCatService.findItemPreviews(checklistId, id);
 
         return LargeCatItemResponse.from(largeCatItem)
                 .withSmallCatItems(itemPreviews);

--- a/src/main/java/org/swyp/weddy/domain/checklist/service/LargeCatServiceImpl.java
+++ b/src/main/java/org/swyp/weddy/domain/checklist/service/LargeCatServiceImpl.java
@@ -13,8 +13,8 @@ public class LargeCatServiceImpl implements LargeCatService {
     }
 
     @Override
-    public LargeCatItemResponse findItem(Long memberId, Long id) {
-        LargeCatItem largeCatItem = mapper.selectItem(memberId, id);
+    public LargeCatItemResponse findItem(Long checklistId, Long id) {
+        LargeCatItem largeCatItem = mapper.selectItem(checklistId, id);
         return LargeCatItemResponse.from(largeCatItem);
     }
 }

--- a/src/main/java/org/swyp/weddy/domain/checklist/service/LargeCatServiceImpl.java
+++ b/src/main/java/org/swyp/weddy/domain/checklist/service/LargeCatServiceImpl.java
@@ -1,7 +1,9 @@
 package org.swyp.weddy.domain.checklist.service;
 
+import org.swyp.weddy.common.exception.ErrorCode;
 import org.swyp.weddy.domain.checklist.dao.LargeCatMapper;
 import org.swyp.weddy.domain.checklist.entity.LargeCatItem;
+import org.swyp.weddy.domain.checklist.exception.LargeCatItemNotExistsException;
 import org.swyp.weddy.domain.checklist.web.response.LargeCatItemResponse;
 
 public class LargeCatServiceImpl implements LargeCatService {
@@ -15,6 +17,11 @@ public class LargeCatServiceImpl implements LargeCatService {
     @Override
     public LargeCatItemResponse findItem(Long checklistId, Long id) {
         LargeCatItem largeCatItem = mapper.selectItem(checklistId, id);
+
+        if (largeCatItem == null) {
+            throw new LargeCatItemNotExistsException(ErrorCode.NOT_EXISTS);
+        }
+
         return LargeCatItemResponse.from(largeCatItem);
     }
 }

--- a/src/main/java/org/swyp/weddy/domain/checklist/service/LargeCatServiceImpl.java
+++ b/src/main/java/org/swyp/weddy/domain/checklist/service/LargeCatServiceImpl.java
@@ -83,7 +83,7 @@ public class LargeCatServiceImpl implements LargeCatService {
         }
 
         LargeCatItem largeCatItem = LargeCatItem.ofDelete(itemBeforeDelete, dto);
-        mapper.updateItem(largeCatItem);
+        mapper.deleteItem(largeCatItem);
 
         return largeCatItem.getId();
     }

--- a/src/main/java/org/swyp/weddy/domain/checklist/service/LargeCatServiceImpl.java
+++ b/src/main/java/org/swyp/weddy/domain/checklist/service/LargeCatServiceImpl.java
@@ -76,6 +76,15 @@ public class LargeCatServiceImpl implements LargeCatService {
 
     @Override
     public Long deleteItem(LargeCatItemDeleteDto dto) {
-        return 0L;
+        LargeCatItem itemBeforeDelete = mapper.selectItem(dto.getChecklistId(), dto.getId());
+
+        if (itemBeforeDelete == null) {
+            throw new LargeCatItemNotExistsException(ErrorCode.NOT_EXISTS);
+        }
+
+        LargeCatItem largeCatItem = LargeCatItem.ofDelete(itemBeforeDelete, dto);
+        mapper.updateItem(largeCatItem);
+
+        return largeCatItem.getId();
     }
 }

--- a/src/main/java/org/swyp/weddy/domain/checklist/service/LargeCatServiceImpl.java
+++ b/src/main/java/org/swyp/weddy/domain/checklist/service/LargeCatServiceImpl.java
@@ -59,6 +59,7 @@ public class LargeCatServiceImpl implements LargeCatService {
         return largeCatItem.getId();
     }
 
+    @Transactional
     @Override
     public Long editItem(LargeCatItemEditDto dto) {
         LargeCatItem itemBeforeEdit = mapper.selectItem(dto.getChecklistId(), dto.getId());

--- a/src/main/java/org/swyp/weddy/domain/checklist/service/LargeCatServiceImpl.java
+++ b/src/main/java/org/swyp/weddy/domain/checklist/service/LargeCatServiceImpl.java
@@ -1,10 +1,20 @@
 package org.swyp.weddy.domain.checklist.service;
 
+import org.swyp.weddy.domain.checklist.dao.LargeCatMapper;
+import org.swyp.weddy.domain.checklist.entity.LargeCatItem;
 import org.swyp.weddy.domain.checklist.web.response.LargeCatItemResponse;
 
 public class LargeCatServiceImpl implements LargeCatService {
+
+    private final LargeCatMapper mapper;
+
+    public LargeCatServiceImpl(LargeCatMapper mapper) {
+        this.mapper = mapper;
+    }
+
     @Override
     public LargeCatItemResponse findItem(Long memberId, Long id) {
-        return new LargeCatItemResponse();
+        LargeCatItem largeCatItem = mapper.selectItem(memberId, id);
+        return LargeCatItemResponse.from(largeCatItem);
     }
 }

--- a/src/main/java/org/swyp/weddy/domain/checklist/service/LargeCatServiceImpl.java
+++ b/src/main/java/org/swyp/weddy/domain/checklist/service/LargeCatServiceImpl.java
@@ -1,6 +1,7 @@
 package org.swyp.weddy.domain.checklist.service;
 
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import org.swyp.weddy.common.exception.ErrorCode;
 import org.swyp.weddy.domain.checklist.dao.LargeCatMapper;
 import org.swyp.weddy.domain.checklist.entity.LargeCatItem;
@@ -28,8 +29,12 @@ public class LargeCatServiceImpl implements LargeCatService {
         return LargeCatItemResponse.from(largeCatItem);
     }
 
+    @Transactional
     @Override
     public Long addItem(LargeCatItemAssignDto dto) {
-        return 1L;
+        LargeCatItem largeCatItem = LargeCatItem.from(dto);
+        mapper.insertItem(largeCatItem);
+
+        return largeCatItem.getId();
     }
 }

--- a/src/main/java/org/swyp/weddy/domain/checklist/service/LargeCatServiceImpl.java
+++ b/src/main/java/org/swyp/weddy/domain/checklist/service/LargeCatServiceImpl.java
@@ -91,9 +91,21 @@ public class LargeCatServiceImpl implements LargeCatService {
         return largeCatItem.getId();
     }
 
+    @Transactional
     @Override
     public Long deleteItemWithSmallItems(LargeCatItemDeleteDto dto) {
-        return 0L;
+        LargeCatItem itemBeforeDelete = mapper.selectItem(dto.getChecklistId(), dto.getId());
+
+        if (itemBeforeDelete == null) {
+            throw new LargeCatItemNotExistsException(ErrorCode.NOT_EXISTS);
+        }
+
+        smallCatService.deleteAll(dto.getChecklistId(), dto.getId());
+
+        LargeCatItem largeCatItem = LargeCatItem.ofDelete(itemBeforeDelete, dto);
+        mapper.deleteItem(largeCatItem);
+
+        return largeCatItem.getId();
     }
 
     @Override

--- a/src/main/java/org/swyp/weddy/domain/checklist/service/LargeCatServiceImpl.java
+++ b/src/main/java/org/swyp/weddy/domain/checklist/service/LargeCatServiceImpl.java
@@ -1,11 +1,13 @@
 package org.swyp.weddy.domain.checklist.service;
 
+import org.springframework.stereotype.Service;
 import org.swyp.weddy.common.exception.ErrorCode;
 import org.swyp.weddy.domain.checklist.dao.LargeCatMapper;
 import org.swyp.weddy.domain.checklist.entity.LargeCatItem;
 import org.swyp.weddy.domain.checklist.exception.LargeCatItemNotExistsException;
 import org.swyp.weddy.domain.checklist.web.response.LargeCatItemResponse;
 
+@Service
 public class LargeCatServiceImpl implements LargeCatService {
 
     private final LargeCatMapper mapper;

--- a/src/main/java/org/swyp/weddy/domain/checklist/service/LargeCatServiceImpl.java
+++ b/src/main/java/org/swyp/weddy/domain/checklist/service/LargeCatServiceImpl.java
@@ -68,7 +68,7 @@ public class LargeCatServiceImpl implements LargeCatService {
             throw new LargeCatItemNotExistsException(ErrorCode.NOT_EXISTS);
         }
 
-        LargeCatItem largeCatItem = LargeCatItem.of(itemBeforeEdit, dto);
+        LargeCatItem largeCatItem = LargeCatItem.ofEdit(itemBeforeEdit, dto);
         mapper.updateItem(largeCatItem);
 
         return largeCatItem.getId();

--- a/src/main/java/org/swyp/weddy/domain/checklist/service/LargeCatServiceImpl.java
+++ b/src/main/java/org/swyp/weddy/domain/checklist/service/LargeCatServiceImpl.java
@@ -8,14 +8,20 @@ import org.swyp.weddy.domain.checklist.entity.LargeCatItem;
 import org.swyp.weddy.domain.checklist.exception.LargeCatItemNotExistsException;
 import org.swyp.weddy.domain.checklist.service.dto.LargeCatItemAssignDto;
 import org.swyp.weddy.domain.checklist.web.response.LargeCatItemResponse;
+import org.swyp.weddy.domain.smallcategory.service.SmallCatService;
+import org.swyp.weddy.domain.smallcategory.web.response.SmallCatItemPreviewResponse;
+
+import java.util.List;
 
 @Service
 public class LargeCatServiceImpl implements LargeCatService {
 
     private final LargeCatMapper mapper;
+    private final SmallCatService smallCatService;
 
-    public LargeCatServiceImpl(LargeCatMapper mapper) {
+    public LargeCatServiceImpl(LargeCatMapper mapper, SmallCatService smallCatService) {
         this.mapper = mapper;
+        this.smallCatService = smallCatService;
     }
 
     @Override
@@ -27,6 +33,19 @@ public class LargeCatServiceImpl implements LargeCatService {
         }
 
         return LargeCatItemResponse.from(largeCatItem);
+    }
+
+    @Override
+    public LargeCatItemResponse findItemWithSmallItems(Long checklistId, Long id) {
+        LargeCatItem largeCatItem = mapper.selectItem(checklistId, id);
+        List<SmallCatItemPreviewResponse> itemPreviews = smallCatService.findItemPreviews(checklistId, id);
+
+        if (largeCatItem == null) {
+            throw new LargeCatItemNotExistsException(ErrorCode.NOT_EXISTS);
+        }
+
+        return LargeCatItemResponse.from(largeCatItem)
+                .withSmallCatItems(itemPreviews);
     }
 
     @Transactional

--- a/src/main/java/org/swyp/weddy/domain/checklist/service/LargeCatServiceImpl.java
+++ b/src/main/java/org/swyp/weddy/domain/checklist/service/LargeCatServiceImpl.java
@@ -5,6 +5,7 @@ import org.swyp.weddy.common.exception.ErrorCode;
 import org.swyp.weddy.domain.checklist.dao.LargeCatMapper;
 import org.swyp.weddy.domain.checklist.entity.LargeCatItem;
 import org.swyp.weddy.domain.checklist.exception.LargeCatItemNotExistsException;
+import org.swyp.weddy.domain.checklist.service.dto.LargeCatItemAssignDto;
 import org.swyp.weddy.domain.checklist.web.response.LargeCatItemResponse;
 
 @Service
@@ -25,5 +26,10 @@ public class LargeCatServiceImpl implements LargeCatService {
         }
 
         return LargeCatItemResponse.from(largeCatItem);
+    }
+
+    @Override
+    public Long addItem(LargeCatItemAssignDto dto) {
+        return 1L;
     }
 }

--- a/src/main/java/org/swyp/weddy/domain/checklist/service/LargeCatServiceImpl.java
+++ b/src/main/java/org/swyp/weddy/domain/checklist/service/LargeCatServiceImpl.java
@@ -60,6 +60,15 @@ public class LargeCatServiceImpl implements LargeCatService {
 
     @Override
     public Long editItem(LargeCatItemEditDto dto) {
-        return 1L;
+        LargeCatItem itemBeforeEdit = mapper.selectItem(dto.getChecklistId(), dto.getId());
+
+        if (itemBeforeEdit == null) {
+            throw new LargeCatItemNotExistsException(ErrorCode.NOT_EXISTS);
+        }
+
+        LargeCatItem largeCatItem = LargeCatItem.of(itemBeforeEdit, dto);
+        mapper.updateItem(largeCatItem);
+
+        return largeCatItem.getId();
     }
 }

--- a/src/main/java/org/swyp/weddy/domain/checklist/service/LargeCatServiceImpl.java
+++ b/src/main/java/org/swyp/weddy/domain/checklist/service/LargeCatServiceImpl.java
@@ -76,6 +76,7 @@ public class LargeCatServiceImpl implements LargeCatService {
         return largeCatItem.getId();
     }
 
+    @Transactional
     @Override
     public Long deleteItem(LargeCatItemDeleteDto dto) {
         LargeCatItem itemBeforeDelete = mapper.selectItem(dto.getChecklistId(), dto.getId());

--- a/src/main/java/org/swyp/weddy/domain/checklist/service/LargeCatServiceImpl.java
+++ b/src/main/java/org/swyp/weddy/domain/checklist/service/LargeCatServiceImpl.java
@@ -7,6 +7,7 @@ import org.swyp.weddy.domain.checklist.dao.LargeCatMapper;
 import org.swyp.weddy.domain.checklist.entity.LargeCatItem;
 import org.swyp.weddy.domain.checklist.exception.LargeCatItemNotExistsException;
 import org.swyp.weddy.domain.checklist.service.dto.LargeCatItemAssignDto;
+import org.swyp.weddy.domain.checklist.service.dto.LargeCatItemEditDto;
 import org.swyp.weddy.domain.checklist.web.response.LargeCatItemResponse;
 import org.swyp.weddy.domain.smallcategory.service.SmallCatService;
 import org.swyp.weddy.domain.smallcategory.web.response.SmallCatItemPreviewResponse;
@@ -55,5 +56,10 @@ public class LargeCatServiceImpl implements LargeCatService {
         mapper.insertItem(largeCatItem);
 
         return largeCatItem.getId();
+    }
+
+    @Override
+    public Long editItem(LargeCatItemEditDto dto) {
+        return 1L;
     }
 }

--- a/src/main/java/org/swyp/weddy/domain/checklist/service/LargeCatServiceImpl.java
+++ b/src/main/java/org/swyp/weddy/domain/checklist/service/LargeCatServiceImpl.java
@@ -1,0 +1,10 @@
+package org.swyp.weddy.domain.checklist.service;
+
+import org.swyp.weddy.domain.checklist.web.response.LargeCatItemResponse;
+
+public class LargeCatServiceImpl implements LargeCatService {
+    @Override
+    public LargeCatItemResponse findItem(Long memberId, Long id) {
+        return new LargeCatItemResponse();
+    }
+}

--- a/src/main/java/org/swyp/weddy/domain/checklist/service/LargeCatServiceImpl.java
+++ b/src/main/java/org/swyp/weddy/domain/checklist/service/LargeCatServiceImpl.java
@@ -87,4 +87,9 @@ public class LargeCatServiceImpl implements LargeCatService {
 
         return largeCatItem.getId();
     }
+
+    @Override
+    public List<LargeCatItemResponse> findAllItems(Long checklistId) {
+        return null;
+    }
 }

--- a/src/main/java/org/swyp/weddy/domain/checklist/service/LargeCatServiceImpl.java
+++ b/src/main/java/org/swyp/weddy/domain/checklist/service/LargeCatServiceImpl.java
@@ -7,6 +7,7 @@ import org.swyp.weddy.domain.checklist.dao.LargeCatMapper;
 import org.swyp.weddy.domain.checklist.entity.LargeCatItem;
 import org.swyp.weddy.domain.checklist.exception.LargeCatItemNotExistsException;
 import org.swyp.weddy.domain.checklist.service.dto.LargeCatItemAssignDto;
+import org.swyp.weddy.domain.checklist.service.dto.LargeCatItemDeleteDto;
 import org.swyp.weddy.domain.checklist.service.dto.LargeCatItemEditDto;
 import org.swyp.weddy.domain.checklist.web.response.LargeCatItemResponse;
 import org.swyp.weddy.domain.smallcategory.service.SmallCatService;
@@ -70,5 +71,10 @@ public class LargeCatServiceImpl implements LargeCatService {
         mapper.updateItem(largeCatItem);
 
         return largeCatItem.getId();
+    }
+
+    @Override
+    public Long deleteItem(LargeCatItemDeleteDto dto) {
+        return 0L;
     }
 }

--- a/src/main/java/org/swyp/weddy/domain/checklist/service/LargeCatServiceImpl.java
+++ b/src/main/java/org/swyp/weddy/domain/checklist/service/LargeCatServiceImpl.java
@@ -13,6 +13,7 @@ import org.swyp.weddy.domain.checklist.web.response.LargeCatItemResponse;
 import org.swyp.weddy.domain.smallcategory.service.SmallCatService;
 import org.swyp.weddy.domain.smallcategory.web.response.SmallCatItemPreviewResponse;
 
+import java.util.ArrayList;
 import java.util.List;
 
 @Service
@@ -91,6 +92,22 @@ public class LargeCatServiceImpl implements LargeCatService {
 
     @Override
     public List<LargeCatItemResponse> findAllItems(Long checklistId) {
-        return null;
+        List<LargeCatItem> allItems = mapper.selectAllItems(checklistId);
+
+        if (allItems == null) {
+            throw new LargeCatItemNotExistsException(ErrorCode.NOT_EXISTS);
+        }
+
+        List<LargeCatItemResponse> result = new ArrayList<>();
+        for (LargeCatItem item : allItems) {
+            List<SmallCatItemPreviewResponse> itemPreviews = smallCatService.findItemPreviews(
+                    checklistId, item.getId()
+            );
+
+            LargeCatItemResponse itemWithSmallItems = LargeCatItemResponse.from(item).withSmallCatItems(itemPreviews);
+            result.add(itemWithSmallItems);
+        }
+
+        return result;
     }
 }

--- a/src/main/java/org/swyp/weddy/domain/checklist/service/LargeCatServiceImpl.java
+++ b/src/main/java/org/swyp/weddy/domain/checklist/service/LargeCatServiceImpl.java
@@ -91,6 +91,11 @@ public class LargeCatServiceImpl implements LargeCatService {
     }
 
     @Override
+    public Long deleteItemWithSmallItems(LargeCatItemDeleteDto dto) {
+        return 0L;
+    }
+
+    @Override
     public List<LargeCatItemResponse> findAllItems(Long checklistId) {
         List<LargeCatItem> allItems = mapper.selectAllItems(checklistId);
 

--- a/src/main/java/org/swyp/weddy/domain/checklist/service/dto/LargeCatItemAssignDto.java
+++ b/src/main/java/org/swyp/weddy/domain/checklist/service/dto/LargeCatItemAssignDto.java
@@ -8,4 +8,12 @@ public class LargeCatItemAssignDto {
         this.checklistId = checklistId;
         this.title = title;
     }
+
+    public Long getChecklistId() {
+        return checklistId;
+    }
+
+    public String getTitle() {
+        return title;
+    }
 }

--- a/src/main/java/org/swyp/weddy/domain/checklist/service/dto/LargeCatItemAssignDto.java
+++ b/src/main/java/org/swyp/weddy/domain/checklist/service/dto/LargeCatItemAssignDto.java
@@ -1,0 +1,11 @@
+package org.swyp.weddy.domain.checklist.service.dto;
+
+public class LargeCatItemAssignDto {
+    private Long checklistId;
+    private String title;
+
+    public LargeCatItemAssignDto(Long checklistId, String title) {
+        this.checklistId = checklistId;
+        this.title = title;
+    }
+}

--- a/src/main/java/org/swyp/weddy/domain/checklist/service/dto/LargeCatItemDeleteDto.java
+++ b/src/main/java/org/swyp/weddy/domain/checklist/service/dto/LargeCatItemDeleteDto.java
@@ -1,6 +1,11 @@
 package org.swyp.weddy.domain.checklist.service.dto;
 
 public class LargeCatItemDeleteDto {
+    private Long checklistId;
+    private Long id;
+
     public LargeCatItemDeleteDto(Long checklistId, Long id) {
+        this.checklistId = checklistId;
+        this.id = id;
     }
 }

--- a/src/main/java/org/swyp/weddy/domain/checklist/service/dto/LargeCatItemDeleteDto.java
+++ b/src/main/java/org/swyp/weddy/domain/checklist/service/dto/LargeCatItemDeleteDto.java
@@ -8,4 +8,12 @@ public class LargeCatItemDeleteDto {
         this.checklistId = checklistId;
         this.id = id;
     }
+
+    public Long getChecklistId() {
+        return checklistId;
+    }
+
+    public Long getId() {
+        return id;
+    }
 }

--- a/src/main/java/org/swyp/weddy/domain/checklist/service/dto/LargeCatItemDeleteDto.java
+++ b/src/main/java/org/swyp/weddy/domain/checklist/service/dto/LargeCatItemDeleteDto.java
@@ -1,5 +1,7 @@
 package org.swyp.weddy.domain.checklist.service.dto;
 
+import org.swyp.weddy.domain.checklist.web.request.LargeCatItemDeleteRequest;
+
 public class LargeCatItemDeleteDto {
     private Long checklistId;
     private Long id;
@@ -7,6 +9,13 @@ public class LargeCatItemDeleteDto {
     public LargeCatItemDeleteDto(Long checklistId, Long id) {
         this.checklistId = checklistId;
         this.id = id;
+    }
+
+    public static LargeCatItemDeleteDto of(Long checklistId, LargeCatItemDeleteRequest request) {
+        return new LargeCatItemDeleteDto(
+                checklistId,
+                Long.valueOf(request.getId())
+        );
     }
 
     public Long getChecklistId() {

--- a/src/main/java/org/swyp/weddy/domain/checklist/service/dto/LargeCatItemDeleteDto.java
+++ b/src/main/java/org/swyp/weddy/domain/checklist/service/dto/LargeCatItemDeleteDto.java
@@ -1,0 +1,6 @@
+package org.swyp.weddy.domain.checklist.service.dto;
+
+public class LargeCatItemDeleteDto {
+    public LargeCatItemDeleteDto(Long checklistId, Long id) {
+    }
+}

--- a/src/main/java/org/swyp/weddy/domain/checklist/service/dto/LargeCatItemEditDto.java
+++ b/src/main/java/org/swyp/weddy/domain/checklist/service/dto/LargeCatItemEditDto.java
@@ -1,6 +1,25 @@
 package org.swyp.weddy.domain.checklist.service.dto;
 
 public class LargeCatItemEditDto {
+    private Long checklistId;
+    private Long id;
+    private String newTitle;
+
     public LargeCatItemEditDto(Long checklistId, Long id, String newTitle) {
+        this.checklistId = checklistId;
+        this.id = id;
+        this.newTitle = newTitle;
+    }
+
+    public Long getChecklistId() {
+        return checklistId;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public String getNewTitle() {
+        return newTitle;
     }
 }

--- a/src/main/java/org/swyp/weddy/domain/checklist/service/dto/LargeCatItemEditDto.java
+++ b/src/main/java/org/swyp/weddy/domain/checklist/service/dto/LargeCatItemEditDto.java
@@ -1,5 +1,7 @@
 package org.swyp.weddy.domain.checklist.service.dto;
 
+import org.swyp.weddy.domain.checklist.web.request.LargeCatItemEditRequest;
+
 public class LargeCatItemEditDto {
     private Long checklistId;
     private Long id;
@@ -9,6 +11,14 @@ public class LargeCatItemEditDto {
         this.checklistId = checklistId;
         this.id = id;
         this.newTitle = newTitle;
+    }
+
+    public static LargeCatItemEditDto of(Long checklistId, LargeCatItemEditRequest request) {
+        return new LargeCatItemEditDto(
+                checklistId,
+                Long.valueOf(request.getId()),
+                request.getEditedTitle()
+        );
     }
 
     public Long getChecklistId() {

--- a/src/main/java/org/swyp/weddy/domain/checklist/service/dto/LargeCatItemEditDto.java
+++ b/src/main/java/org/swyp/weddy/domain/checklist/service/dto/LargeCatItemEditDto.java
@@ -1,0 +1,6 @@
+package org.swyp.weddy.domain.checklist.service.dto;
+
+public class LargeCatItemEditDto {
+    public LargeCatItemEditDto(Long checklistId, Long id, String newTitle) {
+    }
+}

--- a/src/main/java/org/swyp/weddy/domain/checklist/web/LargeCatController.java
+++ b/src/main/java/org/swyp/weddy/domain/checklist/web/LargeCatController.java
@@ -9,6 +9,7 @@ import org.swyp.weddy.domain.checklist.exception.LargeCatItemNotExistsException;
 import org.swyp.weddy.domain.checklist.service.ChecklistService;
 import org.swyp.weddy.domain.checklist.service.LargeCatService;
 import org.swyp.weddy.domain.checklist.service.dto.ChecklistDto;
+import org.swyp.weddy.domain.checklist.service.dto.LargeCatItemAssignDto;
 import org.swyp.weddy.domain.checklist.web.request.LargeCatItemPostRequest;
 import org.swyp.weddy.domain.checklist.web.response.ChecklistResponse;
 import org.swyp.weddy.domain.checklist.web.response.LargeCatItemResponse;
@@ -48,6 +49,17 @@ public class LargeCatController {
 
     @PostMapping
     public ResponseEntity<Void> postItem(@RequestBody LargeCatItemPostRequest request) {
+        String memberId = request.getMemberId();
+        ChecklistDto dto = ChecklistDto.from(memberId);
+
+        ChecklistResponse checklist = checklistService.findChecklist(dto);
+        if (checklist == null) {
+            throw new ChecklistNotExistsException(ErrorCode.NOT_EXISTS);
+        }
+
+        LargeCatItemAssignDto assignDto = new LargeCatItemAssignDto(checklist.getId(), request.getTitle());
+        largeCatService.addItem(assignDto);
+
         return ResponseEntity.ok().build();
     }
 }

--- a/src/main/java/org/swyp/weddy/domain/checklist/web/LargeCatController.java
+++ b/src/main/java/org/swyp/weddy/domain/checklist/web/LargeCatController.java
@@ -68,7 +68,8 @@ public class LargeCatController {
         return ResponseEntity.ok().build();
     }
 
-    public ResponseEntity<Void> deleteItem(LargeCatItemDeleteRequest request) {
+    @PatchMapping("/delete")
+    public ResponseEntity<Void> deleteItem(@RequestBody LargeCatItemDeleteRequest request) {
         String memberId = request.getMemberId();
         ChecklistDto dto = ChecklistDto.from(memberId);
 

--- a/src/main/java/org/swyp/weddy/domain/checklist/web/LargeCatController.java
+++ b/src/main/java/org/swyp/weddy/domain/checklist/web/LargeCatController.java
@@ -88,7 +88,7 @@ public class LargeCatController {
         ChecklistResponse checklist = checklistService.findChecklist(dto);
 
         LargeCatItemDeleteDto deleteDto = LargeCatItemDeleteDto.of(checklist.getId(), request);
-        largeCatService.deleteItem(deleteDto);
+        largeCatService.deleteItemWithSmallItems(deleteDto);
 
         return ResponseEntity.ok().build();
     }

--- a/src/main/java/org/swyp/weddy/domain/checklist/web/LargeCatController.java
+++ b/src/main/java/org/swyp/weddy/domain/checklist/web/LargeCatController.java
@@ -12,6 +12,7 @@ import org.swyp.weddy.domain.checklist.exception.LargeCatItemNotExistsException;
 import org.swyp.weddy.domain.checklist.service.ChecklistService;
 import org.swyp.weddy.domain.checklist.service.LargeCatService;
 import org.swyp.weddy.domain.checklist.service.dto.ChecklistDto;
+import org.swyp.weddy.domain.checklist.web.request.LargeCatItemPostRequest;
 import org.swyp.weddy.domain.checklist.web.response.ChecklistResponse;
 import org.swyp.weddy.domain.checklist.web.response.LargeCatItemResponse;
 
@@ -45,5 +46,10 @@ public class LargeCatController {
         }
 
         return ResponseEntity.ok().body(item);
+    }
+
+
+    public void postItem(LargeCatItemPostRequest request) {
+
     }
 }

--- a/src/main/java/org/swyp/weddy/domain/checklist/web/LargeCatController.java
+++ b/src/main/java/org/swyp/weddy/domain/checklist/web/LargeCatController.java
@@ -15,6 +15,8 @@ import org.swyp.weddy.domain.checklist.web.request.LargeCatItemPostRequest;
 import org.swyp.weddy.domain.checklist.web.response.ChecklistResponse;
 import org.swyp.weddy.domain.checklist.web.response.LargeCatItemResponse;
 
+import java.util.List;
+
 @Slf4j
 @RestController
 @RequestMapping("/checklist/large-cat-item")
@@ -41,6 +43,9 @@ public class LargeCatController {
         return ResponseEntity.ok().body(item);
     }
 
+    public ResponseEntity<List<LargeCatItemResponse>> getAllItems(@RequestParam(name = "memberId") String memberId) {
+        return null;
+    }
 
     @PostMapping
     public ResponseEntity<Void> postItem(@RequestBody LargeCatItemPostRequest request) {

--- a/src/main/java/org/swyp/weddy/domain/checklist/web/LargeCatController.java
+++ b/src/main/java/org/swyp/weddy/domain/checklist/web/LargeCatController.java
@@ -7,6 +7,7 @@ import org.swyp.weddy.domain.checklist.service.ChecklistService;
 import org.swyp.weddy.domain.checklist.service.LargeCatService;
 import org.swyp.weddy.domain.checklist.service.dto.ChecklistDto;
 import org.swyp.weddy.domain.checklist.service.dto.LargeCatItemAssignDto;
+import org.swyp.weddy.domain.checklist.service.dto.LargeCatItemEditDto;
 import org.swyp.weddy.domain.checklist.web.request.LargeCatItemEditRequest;
 import org.swyp.weddy.domain.checklist.web.request.LargeCatItemPostRequest;
 import org.swyp.weddy.domain.checklist.web.response.ChecklistResponse;
@@ -52,7 +53,16 @@ public class LargeCatController {
         return ResponseEntity.ok().build();
     }
 
+    @PatchMapping
     public ResponseEntity<Void> patchItem(LargeCatItemEditRequest request) {
-        return null;
+        String memberId = request.getMemberId();
+        ChecklistDto dto = ChecklistDto.from(memberId);
+
+        ChecklistResponse checklist = checklistService.findChecklist(dto);
+
+        LargeCatItemEditDto editDto = LargeCatItemEditDto.of(checklist.getId(), request);
+        largeCatService.editItem(editDto);
+
+        return ResponseEntity.ok().build();
     }
 }

--- a/src/main/java/org/swyp/weddy/domain/checklist/web/LargeCatController.java
+++ b/src/main/java/org/swyp/weddy/domain/checklist/web/LargeCatController.java
@@ -8,6 +8,7 @@ import org.swyp.weddy.domain.checklist.service.LargeCatService;
 import org.swyp.weddy.domain.checklist.service.dto.ChecklistDto;
 import org.swyp.weddy.domain.checklist.service.dto.LargeCatItemAssignDto;
 import org.swyp.weddy.domain.checklist.service.dto.LargeCatItemEditDto;
+import org.swyp.weddy.domain.checklist.web.request.LargeCatItemDeleteRequest;
 import org.swyp.weddy.domain.checklist.web.request.LargeCatItemEditRequest;
 import org.swyp.weddy.domain.checklist.web.request.LargeCatItemPostRequest;
 import org.swyp.weddy.domain.checklist.web.response.ChecklistResponse;
@@ -64,5 +65,9 @@ public class LargeCatController {
         largeCatService.editItem(editDto);
 
         return ResponseEntity.ok().build();
+    }
+
+    public ResponseEntity<Void> deleteItem(LargeCatItemDeleteRequest request) {
+        return null;
     }
 }

--- a/src/main/java/org/swyp/weddy/domain/checklist/web/LargeCatController.java
+++ b/src/main/java/org/swyp/weddy/domain/checklist/web/LargeCatController.java
@@ -7,6 +7,7 @@ import org.swyp.weddy.domain.checklist.service.ChecklistService;
 import org.swyp.weddy.domain.checklist.service.LargeCatService;
 import org.swyp.weddy.domain.checklist.service.dto.ChecklistDto;
 import org.swyp.weddy.domain.checklist.service.dto.LargeCatItemAssignDto;
+import org.swyp.weddy.domain.checklist.service.dto.LargeCatItemDeleteDto;
 import org.swyp.weddy.domain.checklist.service.dto.LargeCatItemEditDto;
 import org.swyp.weddy.domain.checklist.web.request.LargeCatItemDeleteRequest;
 import org.swyp.weddy.domain.checklist.web.request.LargeCatItemEditRequest;
@@ -68,6 +69,14 @@ public class LargeCatController {
     }
 
     public ResponseEntity<Void> deleteItem(LargeCatItemDeleteRequest request) {
-        return null;
+        String memberId = request.getMemberId();
+        ChecklistDto dto = ChecklistDto.from(memberId);
+
+        ChecklistResponse checklist = checklistService.findChecklist(dto);
+
+        LargeCatItemDeleteDto deleteDto = LargeCatItemDeleteDto.of(checklist.getId(), request);
+        largeCatService.deleteItem(deleteDto);
+
+        return ResponseEntity.ok().build();
     }
 }

--- a/src/main/java/org/swyp/weddy/domain/checklist/web/LargeCatController.java
+++ b/src/main/java/org/swyp/weddy/domain/checklist/web/LargeCatController.java
@@ -29,10 +29,10 @@ public class LargeCatController {
         this.checklistService = checklistService;
     }
 
-    @GetMapping
+    @GetMapping("/{id}")
     public ResponseEntity<LargeCatItemResponse> getItem(
-            @RequestParam(name = "memberId") String memberId,
-            @RequestParam(name = "id") String id
+            @PathVariable(name = "id") String id,
+            @RequestParam(name = "memberId") String memberId
     ) {
         ChecklistDto dto = ChecklistDto.from(memberId);
         ChecklistResponse checklist = checklistService.findChecklist(dto);

--- a/src/main/java/org/swyp/weddy/domain/checklist/web/LargeCatController.java
+++ b/src/main/java/org/swyp/weddy/domain/checklist/web/LargeCatController.java
@@ -38,7 +38,7 @@ public class LargeCatController {
         }
 
         Long checklistId = checklist.getId();
-        LargeCatItemResponse item = largeCatService.findItem(checklistId, Long.valueOf(id));
+        LargeCatItemResponse item = largeCatService.findItemWithSmallItems(checklistId, Long.valueOf(id));
         if (item == null) {
             throw new LargeCatItemNotExistsException(ErrorCode.NOT_EXISTS);
         }

--- a/src/main/java/org/swyp/weddy/domain/checklist/web/LargeCatController.java
+++ b/src/main/java/org/swyp/weddy/domain/checklist/web/LargeCatController.java
@@ -7,6 +7,7 @@ import org.swyp.weddy.domain.checklist.service.ChecklistService;
 import org.swyp.weddy.domain.checklist.service.LargeCatService;
 import org.swyp.weddy.domain.checklist.service.dto.ChecklistDto;
 import org.swyp.weddy.domain.checklist.service.dto.LargeCatItemAssignDto;
+import org.swyp.weddy.domain.checklist.web.request.LargeCatItemEditRequest;
 import org.swyp.weddy.domain.checklist.web.request.LargeCatItemPostRequest;
 import org.swyp.weddy.domain.checklist.web.response.ChecklistResponse;
 import org.swyp.weddy.domain.checklist.web.response.LargeCatItemResponse;
@@ -49,5 +50,9 @@ public class LargeCatController {
         largeCatService.addItem(assignDto);
 
         return ResponseEntity.ok().build();
+    }
+
+    public ResponseEntity<Void> patchItem(LargeCatItemEditRequest request) {
+        return null;
     }
 }

--- a/src/main/java/org/swyp/weddy/domain/checklist/web/LargeCatController.java
+++ b/src/main/java/org/swyp/weddy/domain/checklist/web/LargeCatController.java
@@ -3,9 +3,6 @@ package org.swyp.weddy.domain.checklist.web;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
-import org.swyp.weddy.common.exception.ErrorCode;
-import org.swyp.weddy.domain.checklist.exception.ChecklistNotExistsException;
-import org.swyp.weddy.domain.checklist.exception.LargeCatItemNotExistsException;
 import org.swyp.weddy.domain.checklist.service.ChecklistService;
 import org.swyp.weddy.domain.checklist.service.LargeCatService;
 import org.swyp.weddy.domain.checklist.service.dto.ChecklistDto;
@@ -33,15 +30,9 @@ public class LargeCatController {
     ) {
         ChecklistDto dto = ChecklistDto.from(memberId);
         ChecklistResponse checklist = checklistService.findChecklist(dto);
-        if (checklist == null) {
-            throw new ChecklistNotExistsException(ErrorCode.NOT_EXISTS);
-        }
 
         Long checklistId = checklist.getId();
         LargeCatItemResponse item = largeCatService.findItemWithSmallItems(checklistId, Long.valueOf(id));
-        if (item == null) {
-            throw new LargeCatItemNotExistsException(ErrorCode.NOT_EXISTS);
-        }
 
         return ResponseEntity.ok().body(item);
     }
@@ -53,9 +44,6 @@ public class LargeCatController {
         ChecklistDto dto = ChecklistDto.from(memberId);
 
         ChecklistResponse checklist = checklistService.findChecklist(dto);
-        if (checklist == null) {
-            throw new ChecklistNotExistsException(ErrorCode.NOT_EXISTS);
-        }
 
         LargeCatItemAssignDto assignDto = new LargeCatItemAssignDto(checklist.getId(), request.getTitle());
         largeCatService.addItem(assignDto);

--- a/src/main/java/org/swyp/weddy/domain/checklist/web/LargeCatController.java
+++ b/src/main/java/org/swyp/weddy/domain/checklist/web/LargeCatController.java
@@ -1,0 +1,49 @@
+package org.swyp.weddy.domain.checklist.web;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import org.swyp.weddy.common.exception.ErrorCode;
+import org.swyp.weddy.domain.checklist.exception.ChecklistNotExistsException;
+import org.swyp.weddy.domain.checklist.exception.LargeCatItemNotExistsException;
+import org.swyp.weddy.domain.checklist.service.ChecklistService;
+import org.swyp.weddy.domain.checklist.service.LargeCatService;
+import org.swyp.weddy.domain.checklist.service.dto.ChecklistDto;
+import org.swyp.weddy.domain.checklist.web.response.ChecklistResponse;
+import org.swyp.weddy.domain.checklist.web.response.LargeCatItemResponse;
+
+@Slf4j
+@RestController
+@RequestMapping("/checklist/large-cat-item")
+public class LargeCatController {
+    private final LargeCatService largeCatService;
+    private final ChecklistService checklistService;
+
+    public LargeCatController(LargeCatService largeCatService, ChecklistService checklistService) {
+        this.largeCatService = largeCatService;
+        this.checklistService = checklistService;
+    }
+
+    @GetMapping
+    public ResponseEntity<LargeCatItemResponse> getItem(
+            @RequestParam(name = "memberId") String memberId,
+            @RequestParam(name = "id") String id
+    ) {
+        ChecklistDto dto = ChecklistDto.from(memberId);
+        ChecklistResponse checklist = checklistService.findChecklist(dto);
+        if (checklist == null) {
+            throw new ChecklistNotExistsException(ErrorCode.NOT_EXISTS);
+        }
+
+        Long checklistId = checklist.getId();
+        LargeCatItemResponse item = largeCatService.findItem(checklistId, Long.valueOf(id));
+        if (item == null) {
+            throw new LargeCatItemNotExistsException(ErrorCode.NOT_EXISTS);
+        }
+
+        return ResponseEntity.ok().body(item);
+    }
+}

--- a/src/main/java/org/swyp/weddy/domain/checklist/web/LargeCatController.java
+++ b/src/main/java/org/swyp/weddy/domain/checklist/web/LargeCatController.java
@@ -43,8 +43,15 @@ public class LargeCatController {
         return ResponseEntity.ok().body(item);
     }
 
+    @GetMapping
     public ResponseEntity<List<LargeCatItemResponse>> getAllItems(@RequestParam(name = "memberId") String memberId) {
-        return null;
+        ChecklistDto dto = ChecklistDto.from(memberId);
+        ChecklistResponse checklist = checklistService.findChecklist(dto);
+
+        Long checklistId = checklist.getId();
+        List<LargeCatItemResponse> allItems = largeCatService.findAllItems(checklistId);
+
+        return ResponseEntity.ok().body(allItems);
     }
 
     @PostMapping

--- a/src/main/java/org/swyp/weddy/domain/checklist/web/LargeCatController.java
+++ b/src/main/java/org/swyp/weddy/domain/checklist/web/LargeCatController.java
@@ -2,10 +2,7 @@ package org.swyp.weddy.domain.checklist.web;
 
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 import org.swyp.weddy.common.exception.ErrorCode;
 import org.swyp.weddy.domain.checklist.exception.ChecklistNotExistsException;
 import org.swyp.weddy.domain.checklist.exception.LargeCatItemNotExistsException;
@@ -49,7 +46,8 @@ public class LargeCatController {
     }
 
 
-    public void postItem(LargeCatItemPostRequest request) {
-
+    @PostMapping
+    public ResponseEntity<Void> postItem(@RequestBody LargeCatItemPostRequest request) {
+        return ResponseEntity.ok().build();
     }
 }

--- a/src/main/java/org/swyp/weddy/domain/checklist/web/LargeCatController.java
+++ b/src/main/java/org/swyp/weddy/domain/checklist/web/LargeCatController.java
@@ -54,7 +54,7 @@ public class LargeCatController {
     }
 
     @PatchMapping
-    public ResponseEntity<Void> patchItem(LargeCatItemEditRequest request) {
+    public ResponseEntity<Void> patchItem(@RequestBody LargeCatItemEditRequest request) {
         String memberId = request.getMemberId();
         ChecklistDto dto = ChecklistDto.from(memberId);
 

--- a/src/main/java/org/swyp/weddy/domain/checklist/web/request/LargeCatItemDeleteRequest.java
+++ b/src/main/java/org/swyp/weddy/domain/checklist/web/request/LargeCatItemDeleteRequest.java
@@ -1,0 +1,6 @@
+package org.swyp.weddy.domain.checklist.web.request;
+
+public class LargeCatItemDeleteRequest {
+    public LargeCatItemDeleteRequest(String memberId, String itemId) {
+    }
+}

--- a/src/main/java/org/swyp/weddy/domain/checklist/web/request/LargeCatItemDeleteRequest.java
+++ b/src/main/java/org/swyp/weddy/domain/checklist/web/request/LargeCatItemDeleteRequest.java
@@ -1,6 +1,19 @@
 package org.swyp.weddy.domain.checklist.web.request;
 
 public class LargeCatItemDeleteRequest {
-    public LargeCatItemDeleteRequest(String memberId, String itemId) {
+    private String memberId;
+    private String id;
+
+    public LargeCatItemDeleteRequest(String memberId, String id) {
+        this.memberId = memberId;
+        this.id = id;
+    }
+
+    public String getMemberId() {
+        return memberId;
+    }
+
+    public String getId() {
+        return id;
     }
 }

--- a/src/main/java/org/swyp/weddy/domain/checklist/web/request/LargeCatItemDeleteRequest.java
+++ b/src/main/java/org/swyp/weddy/domain/checklist/web/request/LargeCatItemDeleteRequest.java
@@ -4,6 +4,9 @@ public class LargeCatItemDeleteRequest {
     private String memberId;
     private String id;
 
+    public LargeCatItemDeleteRequest() {
+    }
+
     public LargeCatItemDeleteRequest(String memberId, String id) {
         this.memberId = memberId;
         this.id = id;

--- a/src/main/java/org/swyp/weddy/domain/checklist/web/request/LargeCatItemEditRequest.java
+++ b/src/main/java/org/swyp/weddy/domain/checklist/web/request/LargeCatItemEditRequest.java
@@ -1,6 +1,20 @@
 package org.swyp.weddy.domain.checklist.web.request;
 
 public class LargeCatItemEditRequest {
-    public LargeCatItemEditRequest(String memberId, String editedTitle) {
+    private String memberId;
+    private String id;
+    private String editedTitle;
+
+    public LargeCatItemEditRequest() {
+    }
+
+    public LargeCatItemEditRequest(String memberId, String id, String editedTitle) {
+        this.memberId = memberId;
+        this.id = id;
+        this.editedTitle = editedTitle;
+    }
+
+    public String getMemberId() {
+        return memberId;
     }
 }

--- a/src/main/java/org/swyp/weddy/domain/checklist/web/request/LargeCatItemEditRequest.java
+++ b/src/main/java/org/swyp/weddy/domain/checklist/web/request/LargeCatItemEditRequest.java
@@ -1,0 +1,6 @@
+package org.swyp.weddy.domain.checklist.web.request;
+
+public class LargeCatItemEditRequest {
+    public LargeCatItemEditRequest(String memberId, String editedTitle) {
+    }
+}

--- a/src/main/java/org/swyp/weddy/domain/checklist/web/request/LargeCatItemEditRequest.java
+++ b/src/main/java/org/swyp/weddy/domain/checklist/web/request/LargeCatItemEditRequest.java
@@ -17,4 +17,12 @@ public class LargeCatItemEditRequest {
     public String getMemberId() {
         return memberId;
     }
+
+    public String getId() {
+        return id;
+    }
+
+    public String getEditedTitle() {
+        return editedTitle;
+    }
 }

--- a/src/main/java/org/swyp/weddy/domain/checklist/web/request/LargeCatItemPostRequest.java
+++ b/src/main/java/org/swyp/weddy/domain/checklist/web/request/LargeCatItemPostRequest.java
@@ -1,0 +1,11 @@
+package org.swyp.weddy.domain.checklist.web.request;
+
+public class LargeCatItemPostRequest {
+    private final String memberId;
+    private final String title;
+
+    public LargeCatItemPostRequest(String memberId, String title) {
+        this.memberId = memberId;
+        this.title = title;
+    }
+}

--- a/src/main/java/org/swyp/weddy/domain/checklist/web/request/LargeCatItemPostRequest.java
+++ b/src/main/java/org/swyp/weddy/domain/checklist/web/request/LargeCatItemPostRequest.java
@@ -1,8 +1,11 @@
 package org.swyp.weddy.domain.checklist.web.request;
 
 public class LargeCatItemPostRequest {
-    private final String memberId;
-    private final String title;
+    private String memberId;
+    private String title;
+
+    public LargeCatItemPostRequest() {
+    }
 
     public LargeCatItemPostRequest(String memberId, String title) {
         this.memberId = memberId;

--- a/src/main/java/org/swyp/weddy/domain/checklist/web/request/LargeCatItemPostRequest.java
+++ b/src/main/java/org/swyp/weddy/domain/checklist/web/request/LargeCatItemPostRequest.java
@@ -8,4 +8,12 @@ public class LargeCatItemPostRequest {
         this.memberId = memberId;
         this.title = title;
     }
+
+    public String getMemberId() {
+        return memberId;
+    }
+
+    public String getTitle() {
+        return title;
+    }
 }

--- a/src/main/java/org/swyp/weddy/domain/checklist/web/response/LargeCatItemResponse.java
+++ b/src/main/java/org/swyp/weddy/domain/checklist/web/response/LargeCatItemResponse.java
@@ -1,4 +1,9 @@
 package org.swyp.weddy.domain.checklist.web.response;
 
+import org.swyp.weddy.domain.checklist.entity.LargeCatItem;
+
 public class LargeCatItemResponse {
+    public static LargeCatItemResponse from(LargeCatItem item) {
+        return new LargeCatItemResponse();
+    }
 }

--- a/src/main/java/org/swyp/weddy/domain/checklist/web/response/LargeCatItemResponse.java
+++ b/src/main/java/org/swyp/weddy/domain/checklist/web/response/LargeCatItemResponse.java
@@ -1,0 +1,4 @@
+package org.swyp.weddy.domain.checklist.web.response;
+
+public class LargeCatItemResponse {
+}

--- a/src/main/java/org/swyp/weddy/domain/checklist/web/response/LargeCatItemResponse.java
+++ b/src/main/java/org/swyp/weddy/domain/checklist/web/response/LargeCatItemResponse.java
@@ -3,7 +3,21 @@ package org.swyp.weddy.domain.checklist.web.response;
 import org.swyp.weddy.domain.checklist.entity.LargeCatItem;
 
 public class LargeCatItemResponse {
+    private Long id;
+    private Long checklistId;
+    private String title;
+
+    public LargeCatItemResponse(Long id, Long checklistId, String title) {
+        this.id = id;
+        this.checklistId = checklistId;
+        this.title = title;
+    }
+
     public static LargeCatItemResponse from(LargeCatItem item) {
-        return new LargeCatItemResponse();
+        return new LargeCatItemResponse(
+                item.getId(),
+                item.getChecklistId(),
+                item.getTitle()
+        );
     }
 }

--- a/src/main/java/org/swyp/weddy/domain/checklist/web/response/LargeCatItemResponse.java
+++ b/src/main/java/org/swyp/weddy/domain/checklist/web/response/LargeCatItemResponse.java
@@ -20,4 +20,16 @@ public class LargeCatItemResponse {
                 item.getTitle()
         );
     }
+
+    public Long getId() {
+        return id;
+    }
+
+    public Long getChecklistId() {
+        return checklistId;
+    }
+
+    public String getTitle() {
+        return title;
+    }
 }

--- a/src/main/java/org/swyp/weddy/domain/checklist/web/response/LargeCatItemResponse.java
+++ b/src/main/java/org/swyp/weddy/domain/checklist/web/response/LargeCatItemResponse.java
@@ -1,16 +1,22 @@
 package org.swyp.weddy.domain.checklist.web.response;
 
 import org.swyp.weddy.domain.checklist.entity.LargeCatItem;
+import org.swyp.weddy.domain.smallcategory.web.response.SmallCatItemPreviewResponse;
+
+import java.util.Collections;
+import java.util.List;
 
 public class LargeCatItemResponse {
     private Long id;
     private Long checklistId;
     private String title;
+    private List<SmallCatItemPreviewResponse> smallCatItems;
 
     public LargeCatItemResponse(Long id, Long checklistId, String title) {
         this.id = id;
         this.checklistId = checklistId;
         this.title = title;
+        this.smallCatItems = Collections.emptyList();
     }
 
     public static LargeCatItemResponse from(LargeCatItem item) {
@@ -19,6 +25,11 @@ public class LargeCatItemResponse {
                 item.getChecklistId(),
                 item.getTitle()
         );
+    }
+
+    public LargeCatItemResponse withSmallCatItems(List<SmallCatItemPreviewResponse> smallCatItems) {
+        this.smallCatItems = smallCatItems != null ? smallCatItems : Collections.emptyList();
+        return this;
     }
 
     public Long getId() {
@@ -31,5 +42,9 @@ public class LargeCatItemResponse {
 
     public String getTitle() {
         return title;
+    }
+
+    public List<SmallCatItemPreviewResponse> getSmallCatItems() {
+        return smallCatItems;
     }
 }

--- a/src/main/java/org/swyp/weddy/domain/smallcategory/service/FakeSmallCatService.java
+++ b/src/main/java/org/swyp/weddy/domain/smallcategory/service/FakeSmallCatService.java
@@ -1,0 +1,23 @@
+package org.swyp.weddy.domain.smallcategory.service;
+
+import org.springframework.stereotype.Service;
+import org.swyp.weddy.domain.smallcategory.web.response.SmallCatItemPreviewResponse;
+
+import java.util.Date;
+import java.util.List;
+
+@Service
+public class FakeSmallCatService implements SmallCatService {
+    @Override
+    public List<SmallCatItemPreviewResponse> findItemPreviews(Long checkListId, Long largeCatItemId) {
+        if (largeCatItemId != 1L) {
+            return null;
+        }
+
+        return List.of(
+                new SmallCatItemPreviewResponse(1L, 1L, "t1", new Date(), "세훈", "진행중"),
+                new SmallCatItemPreviewResponse(2L, 1L, "t2", new Date(), "세순", "완료"),
+                new SmallCatItemPreviewResponse(3L, 1L, "t3", new Date(), "세준", "진행중")
+        );
+    }
+}

--- a/src/main/java/org/swyp/weddy/domain/smallcategory/service/FakeSmallCatService.java
+++ b/src/main/java/org/swyp/weddy/domain/smallcategory/service/FakeSmallCatService.java
@@ -20,4 +20,9 @@ public class FakeSmallCatService implements SmallCatService {
                 new SmallCatItemPreviewResponse(3L, 1L, "t3", new Date(), "세준", "진행중")
         );
     }
+
+    @Override
+    public void deleteAll(Long checklistId, Long largeCatItemId) {
+
+    }
 }

--- a/src/main/java/org/swyp/weddy/domain/smallcategory/service/FakeSmallCatService.java
+++ b/src/main/java/org/swyp/weddy/domain/smallcategory/service/FakeSmallCatService.java
@@ -9,7 +9,7 @@ import java.util.List;
 @Service
 public class FakeSmallCatService implements SmallCatService {
     @Override
-    public List<SmallCatItemPreviewResponse> findItemPreviews(Long checkListId, Long largeCatItemId) {
+    public List<SmallCatItemPreviewResponse> findItemPreviews(Long checklistId, Long largeCatItemId) {
         if (largeCatItemId != 1L) {
             return null;
         }

--- a/src/main/java/org/swyp/weddy/domain/smallcategory/service/SmallCatService.java
+++ b/src/main/java/org/swyp/weddy/domain/smallcategory/service/SmallCatService.java
@@ -7,4 +7,5 @@ import java.util.List;
 public interface SmallCatService {
 
     List<SmallCatItemPreviewResponse> findItemPreviews(Long checklistId, Long largeCatItemId); //Long checklistId, Long largeCatId);
+    void deleteAll(Long checklistId, Long largeCatItemId);
 }

--- a/src/main/java/org/swyp/weddy/domain/smallcategory/service/SmallCatService.java
+++ b/src/main/java/org/swyp/weddy/domain/smallcategory/service/SmallCatService.java
@@ -6,5 +6,5 @@ import java.util.List;
 
 public interface SmallCatService {
 
-    List<SmallCatItemPreviewResponse> findItemPreviews(Long checkListId, Long largeCatItemId); //Long checklistId, Long largeCatId);
+    List<SmallCatItemPreviewResponse> findItemPreviews(Long checklistId, Long largeCatItemId); //Long checklistId, Long largeCatId);
 }

--- a/src/main/java/org/swyp/weddy/domain/smallcategory/service/SmallCatService.java
+++ b/src/main/java/org/swyp/weddy/domain/smallcategory/service/SmallCatService.java
@@ -1,0 +1,10 @@
+package org.swyp.weddy.domain.smallcategory.service;
+
+import org.swyp.weddy.domain.smallcategory.web.response.SmallCatItemPreviewResponse;
+
+import java.util.List;
+
+public interface SmallCatService {
+
+    List<SmallCatItemPreviewResponse> findItemPreviews(Long checkListId, Long largeCatItemId); //Long checklistId, Long largeCatId);
+}

--- a/src/main/java/org/swyp/weddy/domain/smallcategory/web/response/SmallCatItemPreviewResponse.java
+++ b/src/main/java/org/swyp/weddy/domain/smallcategory/web/response/SmallCatItemPreviewResponse.java
@@ -1,0 +1,19 @@
+package org.swyp.weddy.domain.smallcategory.web.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.Date;
+
+@AllArgsConstructor
+@NoArgsConstructor
+@Getter
+public class SmallCatItemPreviewResponse {
+    private Long id;
+    private Long largeCatItemId;
+    private String title;
+    private Date dueDate;
+    private String assigneeName;
+    private String statusName;
+}

--- a/src/main/resources/mapper/LargeCatMapper.xml
+++ b/src/main/resources/mapper/LargeCatMapper.xml
@@ -38,4 +38,12 @@
         WHERE checklist_id = #{checklistId}
           AND id = #{id}
     </update>
+
+    <update id="deleteItem" useGeneratedKeys="true" keyProperty="id"
+            parameterType="org.swyp.weddy.domain.checklist.entity.LargeCatItem">
+        UPDATE large_category_item
+        SET is_deleted = #{isDeleted}
+        WHERE checklist_id = #{checklistId}
+          AND id = #{id}
+    </update>
 </mapper>

--- a/src/main/resources/mapper/LargeCatMapper.xml
+++ b/src/main/resources/mapper/LargeCatMapper.xml
@@ -9,8 +9,8 @@
                title,
                created_at,
                updated_at,
-               is_deleted,
-        FROM large_cat_item
+               is_deleted
+        FROM large_category_item
         WHERE id = #{id}
           AND checklist_id = #{checklistId}
     </select>

--- a/src/main/resources/mapper/LargeCatMapper.xml
+++ b/src/main/resources/mapper/LargeCatMapper.xml
@@ -28,4 +28,13 @@
                 #{updatedAt},
                 #{isDeleted})
     </insert>
+
+    <update id="updateItem" useGeneratedKeys="true" keyProperty="id"
+            parameterType="org.swyp.weddy.domain.checklist.entity.LargeCatItem">
+        UPDATE large_category_item
+        SET title      = #{title},
+            updated_at = #{updatedAt}
+        WHERE checklist_id = #{checklistId}
+          AND id = #{id}
+    </update>
 </mapper>

--- a/src/main/resources/mapper/LargeCatMapper.xml
+++ b/src/main/resources/mapper/LargeCatMapper.xml
@@ -13,6 +13,7 @@
         FROM large_category_item
         WHERE id = #{id}
           AND checklist_id = #{checklistId}
+          AND is_deleted = false
     </select>
 
     <insert id="insertItem" useGeneratedKeys="true" keyProperty="id"

--- a/src/main/resources/mapper/LargeCatMapper.xml
+++ b/src/main/resources/mapper/LargeCatMapper.xml
@@ -16,6 +16,18 @@
           AND is_deleted = false
     </select>
 
+    <select id="selectAllItems" parameterType="Long" resultType="org.swyp.weddy.domain.checklist.entity.LargeCatItem">
+        SELECT id,
+               checklist_id,
+               title,
+               created_at,
+               updated_at,
+               is_deleted
+        FROM large_category_item
+        WHERE checklist_id = #{checklistId}
+          AND is_deleted = false
+    </select>
+
     <insert id="insertItem" useGeneratedKeys="true" keyProperty="id"
             parameterType="org.swyp.weddy.domain.checklist.entity.LargeCatItem">
         INSERT INTO large_category_item (checklist_id,

--- a/src/main/resources/mapper/LargeCatMapper.xml
+++ b/src/main/resources/mapper/LargeCatMapper.xml
@@ -42,8 +42,9 @@
     <update id="deleteItem" useGeneratedKeys="true" keyProperty="id"
             parameterType="org.swyp.weddy.domain.checklist.entity.LargeCatItem">
         UPDATE large_category_item
-        SET is_deleted = #{isDeleted}
-        WHERE checklist_id = #{checklistId}
-          AND id = #{id}
+        SET is_deleted = #{isDeleted},
+            updated_at = #{updatedAt}
+        WHERE id = #{id}
+          AND checklist_id = #{checklistId}
     </update>
 </mapper>

--- a/src/main/resources/mapper/LargeCatMapper.xml
+++ b/src/main/resources/mapper/LargeCatMapper.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+
+<mapper namespace="org.swyp.weddy.domain.checklist.dao.LargeCatMapper">
+    <select id="selectItem" resultType="org.swyp.weddy.domain.checklist.entity.LargeCatItem">
+        SELECT id,
+               checklist_id,
+               title,
+               created_at,
+               updated_at,
+               is_deleted,
+        FROM large_cat_item
+        WHERE id = #{id}
+          AND checklist_id = #{checklistId}
+    </select>
+</mapper>

--- a/src/main/resources/mapper/LargeCatMapper.xml
+++ b/src/main/resources/mapper/LargeCatMapper.xml
@@ -14,4 +14,18 @@
         WHERE id = #{id}
           AND checklist_id = #{checklistId}
     </select>
+
+    <insert id="insertItem" useGeneratedKeys="true" keyProperty="id"
+            parameterType="org.swyp.weddy.domain.checklist.entity.LargeCatItem">
+        INSERT INTO large_category_item (checklist_id,
+                                         title,
+                                         created_at,
+                                         updated_at,
+                                         is_deleted)
+        VALUES (#{checklistId},
+                #{title},
+                #{createdAt},
+                #{updatedAt},
+                #{isDeleted})
+    </insert>
 </mapper>

--- a/src/main/resources/sql/data.sql
+++ b/src/main/resources/sql/data.sql
@@ -13,3 +13,5 @@ values (2, null, current_timestamp, null, 0);
 
 insert into `large_category_item` (`checklist_id`, `title`, `created_at`, `updated_at`, `is_deleted`)
 values (1, 'test', current_timestamp, null, 0);
+insert into `large_category_item` (`checklist_id`, `title`, `created_at`, `updated_at`, `is_deleted`)
+values (1, 'test', current_timestamp, null, 1);

--- a/src/main/resources/sql/data.sql
+++ b/src/main/resources/sql/data.sql
@@ -10,3 +10,6 @@ insert into `checklist` (`member_id`, `d_day`, `created_at`, `updated_at`, `is_d
 values (1, 100, current_timestamp, null, 0);
 insert into `checklist` (`member_id`, `d_day`, `created_at`, `updated_at`, `is_deleted`)
 values (2, null, current_timestamp, null, 0);
+
+insert into `large_category_item` (`id`, `checklist_id`, `title`, `created_at`, `updated_at`, `is_deleted`)
+values (1, 1, 'test', current_timestamp, null, 0);

--- a/src/main/resources/sql/data.sql
+++ b/src/main/resources/sql/data.sql
@@ -11,5 +11,5 @@ values (1, 100, current_timestamp, null, 0);
 insert into `checklist` (`member_id`, `d_day`, `created_at`, `updated_at`, `is_deleted`)
 values (2, null, current_timestamp, null, 0);
 
-insert into `large_category_item` (`id`, `checklist_id`, `title`, `created_at`, `updated_at`, `is_deleted`)
-values (1, 1, 'test', current_timestamp, null, 0);
+insert into `large_category_item` (`checklist_id`, `title`, `created_at`, `updated_at`, `is_deleted`)
+values (1, 'test', current_timestamp, null, 0);

--- a/src/main/resources/sql/data.sql
+++ b/src/main/resources/sql/data.sql
@@ -14,4 +14,4 @@ values (2, null, current_timestamp, null, 0);
 insert into `large_category_item` (`checklist_id`, `title`, `created_at`, `updated_at`, `is_deleted`)
 values (1, 'test', current_timestamp, null, 0);
 insert into `large_category_item` (`checklist_id`, `title`, `created_at`, `updated_at`, `is_deleted`)
-values (1, 'test', current_timestamp, null, 1);
+values (1, 'test2', current_timestamp, null, 0);

--- a/src/test/java/org/swyp/weddy/domain/checklist/service/LargeCatServiceTest.java
+++ b/src/test/java/org/swyp/weddy/domain/checklist/service/LargeCatServiceTest.java
@@ -61,5 +61,10 @@ class LargeCatServiceTest {
                     null,
                     Boolean.FALSE);
         }
+
+        @Override
+        public Long insertItem(LargeCatItem item) {
+            return 1L;
+        }
     }
 }

--- a/src/test/java/org/swyp/weddy/domain/checklist/service/LargeCatServiceTest.java
+++ b/src/test/java/org/swyp/weddy/domain/checklist/service/LargeCatServiceTest.java
@@ -126,5 +126,10 @@ class LargeCatServiceTest {
         public Long insertItem(LargeCatItem item) {
             return 1L;
         }
+
+        @Override
+        public Long updateItem(LargeCatItem item) {
+            return 1L;
+        }
     }
 }

--- a/src/test/java/org/swyp/weddy/domain/checklist/service/LargeCatServiceTest.java
+++ b/src/test/java/org/swyp/weddy/domain/checklist/service/LargeCatServiceTest.java
@@ -7,6 +7,7 @@ import org.junit.jupiter.api.Test;
 import org.swyp.weddy.domain.checklist.dao.LargeCatMapper;
 import org.swyp.weddy.domain.checklist.entity.LargeCatItem;
 import org.swyp.weddy.domain.checklist.exception.LargeCatItemNotExistsException;
+import org.swyp.weddy.domain.checklist.service.dto.LargeCatItemAssignDto;
 import org.swyp.weddy.domain.checklist.web.response.LargeCatItemResponse;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -31,6 +32,18 @@ class LargeCatServiceTest {
             Assertions.assertThrows(LargeCatItemNotExistsException.class, () ->
                     largeCatService.findItem(-1L, 1L)
             );
+        }
+    }
+
+    @DisplayName("assignItem()")
+    @Nested
+    class assignItemTest {
+        @DisplayName("대분류 항목 하나를 추가할 수 있다")
+        @Test
+        public void assign_one_large_cat_item() {
+            LargeCatServiceImpl largeCatService = new LargeCatServiceImpl(new FakeLargeCatMapper());
+            Long id = largeCatService.addItem(new LargeCatItemAssignDto(1L, "test"));
+            assertThat(id).isNotNull();
         }
     }
 

--- a/src/test/java/org/swyp/weddy/domain/checklist/service/LargeCatServiceTest.java
+++ b/src/test/java/org/swyp/weddy/domain/checklist/service/LargeCatServiceTest.java
@@ -14,6 +14,7 @@ import org.swyp.weddy.domain.checklist.web.response.LargeCatItemResponse;
 import org.swyp.weddy.domain.smallcategory.service.FakeSmallCatService;
 
 import java.sql.Timestamp;
+import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -68,6 +69,14 @@ class LargeCatServiceTest {
         public void receive_all_items_message() {
             LargeCatServiceImpl largeCatService = new LargeCatServiceImpl(new FakeLargeCatMapper(), new FakeSmallCatService());
             largeCatService.findAllItems(1L);
+        }
+
+        @DisplayName("모든 대분류 항목을 읽어올 수 있다")
+        @Test
+        public void find_all_items() {
+            LargeCatServiceImpl largeCatService = new LargeCatServiceImpl(new FakeLargeCatMapper(), new FakeSmallCatService());
+            List<LargeCatItemResponse> allItems = largeCatService.findAllItems(1L);
+            assertThat(allItems).isNotNull();
         }
     }
 

--- a/src/test/java/org/swyp/weddy/domain/checklist/service/LargeCatServiceTest.java
+++ b/src/test/java/org/swyp/weddy/domain/checklist/service/LargeCatServiceTest.java
@@ -151,5 +151,10 @@ class LargeCatServiceTest {
         public Long updateItem(LargeCatItem item) {
             return 1L;
         }
+
+        @Override
+        public Long deleteItem(LargeCatItem item) {
+            return 0L;
+        }
     }
 }

--- a/src/test/java/org/swyp/weddy/domain/checklist/service/LargeCatServiceTest.java
+++ b/src/test/java/org/swyp/weddy/domain/checklist/service/LargeCatServiceTest.java
@@ -3,7 +3,6 @@ package org.swyp.weddy.domain.checklist.service;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.swyp.weddy.common.exception.ErrorCode;
 import org.swyp.weddy.domain.checklist.dao.LargeCatMapper;
 import org.swyp.weddy.domain.checklist.entity.LargeCatItem;
 import org.swyp.weddy.domain.checklist.exception.LargeCatItemNotExistsException;
@@ -16,7 +15,7 @@ class LargeCatServiceTest {
     @DisplayName("대분류 항목 하나를 가져올 수 있다")
     @Test
     public void find_one_large_cat_item() {
-        LargeCatService largeCatService = new FakeLargeCatService(new FakeLargeCatMapper());
+        LargeCatService largeCatService = new LargeCatServiceImpl(new FakeLargeCatMapper());
         LargeCatItemResponse item = largeCatService.findItem(1L, 1L);
         assertThat(item).isNotNull();
     }
@@ -24,27 +23,10 @@ class LargeCatServiceTest {
     @DisplayName("주어진 대분류 아이디에 등록된 항목이 없을 경우를 처리할 수 있다")
     @Test
     public void no_large_cat_item_for_given_id() {
-        LargeCatService largeCatService = new FakeLargeCatService(new FakeLargeCatMapper());
+        LargeCatService largeCatService = new LargeCatServiceImpl(new FakeLargeCatMapper());
         Assertions.assertThrows(LargeCatItemNotExistsException.class, () ->
                 largeCatService.findItem(-1L, 1L)
         );
-    }
-
-    private static class FakeLargeCatService implements LargeCatService {
-        private final LargeCatMapper mapper;
-
-        public FakeLargeCatService(LargeCatMapper mapper) {
-            this.mapper = mapper;
-        }
-
-        @Override
-        public LargeCatItemResponse findItem(Long checklistId, Long id) {
-            LargeCatItem largeCatItem = mapper.selectItem(checklistId, id);
-            if (largeCatItem == null) {
-                throw new LargeCatItemNotExistsException(ErrorCode.NOT_EXISTS);
-            }
-            return LargeCatItemResponse.from(largeCatItem);
-        }
     }
 
     private static class FakeLargeCatMapper implements LargeCatMapper {

--- a/src/test/java/org/swyp/weddy/domain/checklist/service/LargeCatServiceTest.java
+++ b/src/test/java/org/swyp/weddy/domain/checklist/service/LargeCatServiceTest.java
@@ -35,7 +35,12 @@ class LargeCatServiceTest {
     private static class FakeLargeCatMapper implements LargeCatMapper {
         @Override
         public LargeCatItem selectItem(Long checkListId, Long id) {
-            return new LargeCatItem();
+            return new LargeCatItem(1L,
+                    1L,
+                    "test",
+                    null,
+                    null,
+                    Boolean.FALSE);
         }
     }
 }

--- a/src/test/java/org/swyp/weddy/domain/checklist/service/LargeCatServiceTest.java
+++ b/src/test/java/org/swyp/weddy/domain/checklist/service/LargeCatServiceTest.java
@@ -1,0 +1,41 @@
+package org.swyp.weddy.domain.checklist.service;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.swyp.weddy.domain.checklist.dao.LargeCatMapper;
+import org.swyp.weddy.domain.checklist.entity.LargeCatItem;
+import org.swyp.weddy.domain.checklist.web.response.LargeCatItemResponse;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class LargeCatServiceTest {
+
+    @DisplayName("대분류 항목 하나를 가져올 수 있다")
+    @Test
+    public void find_one_large_cat_item() {
+        LargeCatService largeCatService = new FakeLargeCatService(new FakeLargeCatMapper());
+        LargeCatItemResponse item = largeCatService.findItem(1L, 1L);
+        assertThat(item).isNotNull();
+    }
+
+    private static class FakeLargeCatService implements LargeCatService {
+        private final LargeCatMapper mapper;
+
+        public FakeLargeCatService(LargeCatMapper mapper) {
+            this.mapper = mapper;
+        }
+
+        @Override
+        public LargeCatItemResponse findItem(Long memberId, Long id) {
+            LargeCatItem largeCatItem = mapper.selectItem(memberId, id);
+            return LargeCatItemResponse.from(largeCatItem);
+        }
+    }
+
+    private static class FakeLargeCatMapper implements LargeCatMapper {
+        @Override
+        public LargeCatItem selectItem(Long checkListId, Long id) {
+            return new LargeCatItem();
+        }
+    }
+}

--- a/src/test/java/org/swyp/weddy/domain/checklist/service/LargeCatServiceTest.java
+++ b/src/test/java/org/swyp/weddy/domain/checklist/service/LargeCatServiceTest.java
@@ -163,6 +163,14 @@ class LargeCatServiceTest {
         }
 
         @Override
+        public List<LargeCatItem> selectAllItems(Long checklistId) {
+            return List.of(
+                    new LargeCatItem(1L, 1L, "test", null, null, Boolean.FALSE),
+                    new LargeCatItem(2L, 1L, "test2", null, null, Boolean.FALSE)
+            );
+        }
+
+        @Override
         public Long insertItem(LargeCatItem item) {
             return 1L;
         }

--- a/src/test/java/org/swyp/weddy/domain/checklist/service/LargeCatServiceTest.java
+++ b/src/test/java/org/swyp/weddy/domain/checklist/service/LargeCatServiceTest.java
@@ -60,6 +60,17 @@ class LargeCatServiceTest {
         }
     }
 
+    @DisplayName("findAllItems()")
+    @Nested
+    class FindAllItemsTest {
+        @DisplayName("모든 대분류 항목 읽어오기 요청을 받을 수 있다")
+        @Test
+        public void receive_all_items_message() {
+            LargeCatServiceImpl largeCatService = new LargeCatServiceImpl(new FakeLargeCatMapper(), new FakeSmallCatService());
+            largeCatService.findAllItems(1L);
+        }
+    }
+
     @DisplayName("assignItem()")
     @Nested
     class AssignItemTest {

--- a/src/test/java/org/swyp/weddy/domain/checklist/service/LargeCatServiceTest.java
+++ b/src/test/java/org/swyp/weddy/domain/checklist/service/LargeCatServiceTest.java
@@ -21,7 +21,7 @@ class LargeCatServiceTest {
 
     @DisplayName("findItem()")
     @Nested
-    class findItemTest {
+    class FindItemTest {
         @DisplayName("대분류 항목 하나를 가져올 수 있다")
         @Test
         public void find_one_large_cat_item() {
@@ -42,7 +42,7 @@ class LargeCatServiceTest {
 
     @DisplayName("findItemWithSmallItems()")
     @Nested
-    class findItemWithSmallItemsTest {
+    class FindItemWithSmallItemsTest {
         @DisplayName("대분류 항목에 연결된 소분류 항목(들)을 같이 가져온다")
         @Test
         public void return_value_has_small_cat_items() {
@@ -62,7 +62,7 @@ class LargeCatServiceTest {
 
     @DisplayName("assignItem()")
     @Nested
-    class assignItemTest {
+    class AssignItemTest {
         @DisplayName("대분류 항목 하나를 추가할 수 있다")
         @Test
         public void assign_one_large_cat_item() {
@@ -89,7 +89,7 @@ class LargeCatServiceTest {
 
     @DisplayName("editItem()")
     @Nested
-    class editItemTest {
+    class EditItemTest {
         @DisplayName("대분류 항목 하나를 수정할 수 있다")
         @Test
         public void edit_one_large_cat_item() {
@@ -101,7 +101,7 @@ class LargeCatServiceTest {
 
     @DisplayName("deleteItem()")
     @Nested
-    class deleteItemTest {
+    class DeleteItemTest {
         @DisplayName("대분류 항목 삭제 요청을 받을 수 있다")
         @Test
         public void receive_delete_one_large_cat_item_message() {

--- a/src/test/java/org/swyp/weddy/domain/checklist/service/LargeCatServiceTest.java
+++ b/src/test/java/org/swyp/weddy/domain/checklist/service/LargeCatServiceTest.java
@@ -112,8 +112,8 @@ class LargeCatServiceTest {
 
     private static class FakeLargeCatMapper implements LargeCatMapper {
         @Override
-        public LargeCatItem selectItem(Long checkListId, Long id) {
-            if (checkListId == -1L) {
+        public LargeCatItem selectItem(Long checklistId, Long id) {
+            if (checklistId == -1L) {
                 return null;
             }
 

--- a/src/test/java/org/swyp/weddy/domain/checklist/service/LargeCatServiceTest.java
+++ b/src/test/java/org/swyp/weddy/domain/checklist/service/LargeCatServiceTest.java
@@ -102,8 +102,13 @@ class LargeCatServiceTest {
     @DisplayName("deleteItem()")
     @Nested
     class deleteItemTest {
-        @DisplayName("대분류 항목 하나를 삭제할 수 있다")
+        @DisplayName("대분류 항목 삭제 요청을 받을 수 있다")
         @Test
+        public void receive_delete_one_large_cat_item_message() {
+            LargeCatServiceImpl largeCatService = new LargeCatServiceImpl(new FakeLargeCatMapper(), new FakeSmallCatService());
+            largeCatService.deleteItem(new LargeCatItemDeleteDto(1L, 1L));
+        }
+
         public void delete_one_large_cat_item() {
             LargeCatServiceImpl largeCatService = new LargeCatServiceImpl(new FakeLargeCatMapper(), new FakeSmallCatService());
             largeCatService.deleteItem(new LargeCatItemDeleteDto(1L, 1L));

--- a/src/test/java/org/swyp/weddy/domain/checklist/service/LargeCatServiceTest.java
+++ b/src/test/java/org/swyp/weddy/domain/checklist/service/LargeCatServiceTest.java
@@ -10,6 +10,8 @@ import org.swyp.weddy.domain.checklist.exception.LargeCatItemNotExistsException;
 import org.swyp.weddy.domain.checklist.service.dto.LargeCatItemAssignDto;
 import org.swyp.weddy.domain.checklist.web.response.LargeCatItemResponse;
 
+import java.sql.Timestamp;
+
 import static org.assertj.core.api.Assertions.assertThat;
 
 class LargeCatServiceTest {
@@ -44,6 +46,22 @@ class LargeCatServiceTest {
             LargeCatServiceImpl largeCatService = new LargeCatServiceImpl(new FakeLargeCatMapper());
             Long id = largeCatService.addItem(new LargeCatItemAssignDto(1L, "test"));
             assertThat(id).isNotNull();
+        }
+
+        @DisplayName("dto를 mapper에 보낼 형태로 변환할 수 있다")
+        @Test
+        public void convert_dto_to_entity() {
+            LargeCatItemAssignDto dto = new LargeCatItemAssignDto(1L, "test");
+            LargeCatItem item = LargeCatItem.from(dto);
+            LargeCatItem expected = new LargeCatItem(
+                    1L,
+                    "test",
+                    new Timestamp(System.currentTimeMillis()),
+                    null,
+                    Boolean.FALSE
+            );
+            assertThat(item.getChecklistId()).isEqualTo(expected.getChecklistId());
+            assertThat(item.getTitle()).isEqualTo(expected.getTitle());
         }
     }
 

--- a/src/test/java/org/swyp/weddy/domain/checklist/service/LargeCatServiceTest.java
+++ b/src/test/java/org/swyp/weddy/domain/checklist/service/LargeCatServiceTest.java
@@ -2,6 +2,7 @@ package org.swyp.weddy.domain.checklist.service;
 
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.swyp.weddy.domain.checklist.dao.LargeCatMapper;
 import org.swyp.weddy.domain.checklist.entity.LargeCatItem;
@@ -12,21 +13,25 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 class LargeCatServiceTest {
 
-    @DisplayName("대분류 항목 하나를 가져올 수 있다")
-    @Test
-    public void find_one_large_cat_item() {
-        LargeCatService largeCatService = new LargeCatServiceImpl(new FakeLargeCatMapper());
-        LargeCatItemResponse item = largeCatService.findItem(1L, 1L);
-        assertThat(item).isNotNull();
-    }
+    @DisplayName("findItem()")
+    @Nested
+    class findItemTest {
+        @DisplayName("대분류 항목 하나를 가져올 수 있다")
+        @Test
+        public void find_one_large_cat_item() {
+            LargeCatService largeCatService = new LargeCatServiceImpl(new FakeLargeCatMapper());
+            LargeCatItemResponse item = largeCatService.findItem(1L, 1L);
+            assertThat(item).isNotNull();
+        }
 
-    @DisplayName("주어진 대분류 아이디에 등록된 항목이 없을 경우를 처리할 수 있다")
-    @Test
-    public void no_large_cat_item_for_given_id() {
-        LargeCatService largeCatService = new LargeCatServiceImpl(new FakeLargeCatMapper());
-        Assertions.assertThrows(LargeCatItemNotExistsException.class, () ->
-                largeCatService.findItem(-1L, 1L)
-        );
+        @DisplayName("주어진 대분류 아이디에 등록된 항목이 없을 경우를 처리할 수 있다")
+        @Test
+        public void no_large_cat_item_for_given_id() {
+            LargeCatService largeCatService = new LargeCatServiceImpl(new FakeLargeCatMapper());
+            Assertions.assertThrows(LargeCatItemNotExistsException.class, () ->
+                    largeCatService.findItem(-1L, 1L)
+            );
+        }
     }
 
     private static class FakeLargeCatMapper implements LargeCatMapper {

--- a/src/test/java/org/swyp/weddy/domain/checklist/service/LargeCatServiceTest.java
+++ b/src/test/java/org/swyp/weddy/domain/checklist/service/LargeCatServiceTest.java
@@ -1,9 +1,12 @@
 package org.swyp.weddy.domain.checklist.service;
 
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.swyp.weddy.common.exception.ErrorCode;
 import org.swyp.weddy.domain.checklist.dao.LargeCatMapper;
 import org.swyp.weddy.domain.checklist.entity.LargeCatItem;
+import org.swyp.weddy.domain.checklist.exception.LargeCatItemNotExistsException;
 import org.swyp.weddy.domain.checklist.web.response.LargeCatItemResponse;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -18,6 +21,15 @@ class LargeCatServiceTest {
         assertThat(item).isNotNull();
     }
 
+    @DisplayName("주어진 대분류 아이디에 등록된 항목이 없을 경우를 처리할 수 있다")
+    @Test
+    public void no_large_cat_item_for_given_id() {
+        LargeCatService largeCatService = new FakeLargeCatService(new FakeLargeCatMapper());
+        Assertions.assertThrows(LargeCatItemNotExistsException.class, () ->
+                largeCatService.findItem(-1L, 1L)
+        );
+    }
+
     private static class FakeLargeCatService implements LargeCatService {
         private final LargeCatMapper mapper;
 
@@ -28,6 +40,9 @@ class LargeCatServiceTest {
         @Override
         public LargeCatItemResponse findItem(Long checklistId, Long id) {
             LargeCatItem largeCatItem = mapper.selectItem(checklistId, id);
+            if (largeCatItem == null) {
+                throw new LargeCatItemNotExistsException(ErrorCode.NOT_EXISTS);
+            }
             return LargeCatItemResponse.from(largeCatItem);
         }
     }
@@ -35,6 +50,10 @@ class LargeCatServiceTest {
     private static class FakeLargeCatMapper implements LargeCatMapper {
         @Override
         public LargeCatItem selectItem(Long checkListId, Long id) {
+            if (checkListId == -1L) {
+                return null;
+            }
+
             return new LargeCatItem(1L,
                     1L,
                     "test",

--- a/src/test/java/org/swyp/weddy/domain/checklist/service/LargeCatServiceTest.java
+++ b/src/test/java/org/swyp/weddy/domain/checklist/service/LargeCatServiceTest.java
@@ -8,6 +8,7 @@ import org.swyp.weddy.domain.checklist.dao.LargeCatMapper;
 import org.swyp.weddy.domain.checklist.entity.LargeCatItem;
 import org.swyp.weddy.domain.checklist.exception.LargeCatItemNotExistsException;
 import org.swyp.weddy.domain.checklist.service.dto.LargeCatItemAssignDto;
+import org.swyp.weddy.domain.checklist.service.dto.LargeCatItemDeleteDto;
 import org.swyp.weddy.domain.checklist.service.dto.LargeCatItemEditDto;
 import org.swyp.weddy.domain.checklist.web.response.LargeCatItemResponse;
 import org.swyp.weddy.domain.smallcategory.service.FakeSmallCatService;
@@ -95,6 +96,17 @@ class LargeCatServiceTest {
             LargeCatServiceImpl largeCatService = new LargeCatServiceImpl(new FakeLargeCatMapper(), new FakeSmallCatService());
             Long editItemId = largeCatService.editItem(new LargeCatItemEditDto(1L, 1L, "revised_test"));
             assertThat(editItemId).isNotNull();
+        }
+    }
+
+    @DisplayName("deleteItem()")
+    @Nested
+    class deleteItemTest {
+        @DisplayName("대분류 항목 하나를 삭제할 수 있다")
+        @Test
+        public void delete_one_large_cat_item() {
+            LargeCatServiceImpl largeCatService = new LargeCatServiceImpl(new FakeLargeCatMapper(), new FakeSmallCatService());
+            largeCatService.deleteItem(new LargeCatItemDeleteDto(1L, 1L));
         }
     }
 

--- a/src/test/java/org/swyp/weddy/domain/checklist/service/LargeCatServiceTest.java
+++ b/src/test/java/org/swyp/weddy/domain/checklist/service/LargeCatServiceTest.java
@@ -26,8 +26,8 @@ class LargeCatServiceTest {
         }
 
         @Override
-        public LargeCatItemResponse findItem(Long memberId, Long id) {
-            LargeCatItem largeCatItem = mapper.selectItem(memberId, id);
+        public LargeCatItemResponse findItem(Long checklistId, Long id) {
+            LargeCatItem largeCatItem = mapper.selectItem(checklistId, id);
             return LargeCatItemResponse.from(largeCatItem);
         }
     }

--- a/src/test/java/org/swyp/weddy/domain/checklist/service/LargeCatServiceTest.java
+++ b/src/test/java/org/swyp/weddy/domain/checklist/service/LargeCatServiceTest.java
@@ -8,6 +8,7 @@ import org.swyp.weddy.domain.checklist.dao.LargeCatMapper;
 import org.swyp.weddy.domain.checklist.entity.LargeCatItem;
 import org.swyp.weddy.domain.checklist.exception.LargeCatItemNotExistsException;
 import org.swyp.weddy.domain.checklist.service.dto.LargeCatItemAssignDto;
+import org.swyp.weddy.domain.checklist.service.dto.LargeCatItemEditDto;
 import org.swyp.weddy.domain.checklist.web.response.LargeCatItemResponse;
 import org.swyp.weddy.domain.smallcategory.service.FakeSmallCatService;
 
@@ -82,6 +83,18 @@ class LargeCatServiceTest {
             );
             assertThat(item.getChecklistId()).isEqualTo(expected.getChecklistId());
             assertThat(item.getTitle()).isEqualTo(expected.getTitle());
+        }
+    }
+
+    @DisplayName("editItem()")
+    @Nested
+    class editItemTest {
+        @DisplayName("대분류 항목 하나를 수정할 수 있다")
+        @Test
+        public void edit_one_large_cat_item() {
+            LargeCatServiceImpl largeCatService = new LargeCatServiceImpl(new FakeLargeCatMapper(), new FakeSmallCatService());
+            Long editItemId = largeCatService.editItem(new LargeCatItemEditDto(1L, 1L, "revised_test"));
+            assertThat(editItemId).isNotNull();
         }
     }
 

--- a/src/test/java/org/swyp/weddy/domain/checklist/service/LargeCatServiceTest.java
+++ b/src/test/java/org/swyp/weddy/domain/checklist/service/LargeCatServiceTest.java
@@ -138,6 +138,18 @@ class LargeCatServiceTest {
         }
     }
 
+    @DisplayName("deleteItemWithSmallItems()")
+    @Nested
+    class DeleteItemWithSmallItemsTest {
+        @DisplayName("대분류 항목에 연결된 소분류 항목(들)을 같이 삭제한다")
+        @Test
+        public void return_value_has_small_cat_items() {
+            LargeCatServiceImpl largeCatService = new LargeCatServiceImpl(new FakeLargeCatMapper(), new FakeSmallCatService());
+            Long deletedItemId = largeCatService.deleteItemWithSmallItems(new LargeCatItemDeleteDto(1L, 1L));
+            assertThat(deletedItemId).isNotNull();
+        }
+    }
+
     private static class FakeLargeCatMapper implements LargeCatMapper {
         @Override
         public LargeCatItem selectItem(Long checklistId, Long id) {

--- a/src/test/java/org/swyp/weddy/domain/checklist/service/LargeCatServiceTest.java
+++ b/src/test/java/org/swyp/weddy/domain/checklist/service/LargeCatServiceTest.java
@@ -109,9 +109,12 @@ class LargeCatServiceTest {
             largeCatService.deleteItem(new LargeCatItemDeleteDto(1L, 1L));
         }
 
+        @DisplayName("대분류 항목을 삭제할 수 있다")
+        @Test
         public void delete_one_large_cat_item() {
             LargeCatServiceImpl largeCatService = new LargeCatServiceImpl(new FakeLargeCatMapper(), new FakeSmallCatService());
-            largeCatService.deleteItem(new LargeCatItemDeleteDto(1L, 1L));
+            Long deletedItemId = largeCatService.deleteItem(new LargeCatItemDeleteDto(1L, 1L));
+            assertThat(deletedItemId).isNotNull();
         }
     }
 

--- a/src/test/java/org/swyp/weddy/domain/checklist/service/LargeCatServiceTest.java
+++ b/src/test/java/org/swyp/weddy/domain/checklist/service/LargeCatServiceTest.java
@@ -44,8 +44,7 @@ class LargeCatServiceTest {
         @Test
         public void assign_one_large_cat_item() {
             LargeCatServiceImpl largeCatService = new LargeCatServiceImpl(new FakeLargeCatMapper());
-            Long id = largeCatService.addItem(new LargeCatItemAssignDto(1L, "test"));
-            assertThat(id).isNotNull();
+            largeCatService.addItem(new LargeCatItemAssignDto(1L, "test"));
         }
 
         @DisplayName("dto를 mapper에 보낼 형태로 변환할 수 있다")

--- a/src/test/java/org/swyp/weddy/domain/checklist/web/LargeCatControllerTest.java
+++ b/src/test/java/org/swyp/weddy/domain/checklist/web/LargeCatControllerTest.java
@@ -9,6 +9,7 @@ import org.swyp.weddy.domain.checklist.service.LargeCatService;
 import org.swyp.weddy.domain.checklist.service.dto.ChecklistDto;
 import org.swyp.weddy.domain.checklist.service.dto.LargeCatItemAssignDto;
 import org.swyp.weddy.domain.checklist.service.dto.LargeCatItemEditDto;
+import org.swyp.weddy.domain.checklist.web.request.LargeCatItemEditRequest;
 import org.swyp.weddy.domain.checklist.web.request.LargeCatItemPostRequest;
 import org.swyp.weddy.domain.checklist.web.response.ChecklistResponse;
 import org.swyp.weddy.domain.checklist.web.response.LargeCatItemResponse;
@@ -59,6 +60,25 @@ class LargeCatControllerTest {
             LargeCatItemPostRequest request = new LargeCatItemPostRequest("1L", "test");
 
             assertThat(controller.postItem(request)).isEqualTo(ResponseEntity.ok().build());
+        }
+    }
+
+    @DisplayName("patchItem()")
+    @Nested
+    class patchItemTest {
+        @DisplayName("대분류 항목 수정 요청을 받을 수 있다")
+        @Test
+        public void patch_large_item() {
+            LargeCatController controller = new LargeCatController(
+                    new FakeLargeCatService(),
+                    new FakeChecklistService()
+            );
+            String memberId = "1L";
+            String editedTitle = "test_revised";
+
+            LargeCatItemEditRequest request = new LargeCatItemEditRequest(memberId, editedTitle);
+
+            controller.patchItem(request);
         }
     }
 

--- a/src/test/java/org/swyp/weddy/domain/checklist/web/LargeCatControllerTest.java
+++ b/src/test/java/org/swyp/weddy/domain/checklist/web/LargeCatControllerTest.java
@@ -74,9 +74,10 @@ class LargeCatControllerTest {
                     new FakeChecklistService()
             );
             String memberId = "1L";
+            String itemId = "1L";
             String editedTitle = "test_revised";
 
-            LargeCatItemEditRequest request = new LargeCatItemEditRequest(memberId, editedTitle);
+            LargeCatItemEditRequest request = new LargeCatItemEditRequest(memberId, itemId, editedTitle);
 
             controller.patchItem(request);
         }

--- a/src/test/java/org/swyp/weddy/domain/checklist/web/LargeCatControllerTest.java
+++ b/src/test/java/org/swyp/weddy/domain/checklist/web/LargeCatControllerTest.java
@@ -21,7 +21,7 @@ class LargeCatControllerTest {
 
     @DisplayName("getItem()")
     @Nested
-    class getItemTest {
+    class GetItemTest {
         @DisplayName("대분류 항목 하나를 가져올 수 있다")
         @Test
         public void get_large_item() {
@@ -36,7 +36,7 @@ class LargeCatControllerTest {
 
     @DisplayName("postItem()")
     @Nested
-    class postItemTest {
+    class PostItemTest {
         @DisplayName("대분류 항목 추가 요청을 받을 수 있다")
         @Test
         public void post_large_item() {
@@ -66,7 +66,7 @@ class LargeCatControllerTest {
 
     @DisplayName("patchItem()")
     @Nested
-    class patchItemTest {
+    class PatchItemTest {
         @DisplayName("대분류 항목 수정 요청을 받을 수 있다")
         @Test
         public void patch_large_item() {

--- a/src/test/java/org/swyp/weddy/domain/checklist/web/LargeCatControllerTest.java
+++ b/src/test/java/org/swyp/weddy/domain/checklist/web/LargeCatControllerTest.java
@@ -49,6 +49,18 @@ class LargeCatControllerTest {
             );
             controller.getAllItems("1");
         }
+
+        @DisplayName("모든 대분류 항목 가져오기 결과를 반환할 수 있다")
+        @Test
+        public void returns_all_large_items() {
+            LargeCatController controller = new LargeCatController(
+                    new FakeLargeCatService(),
+                    new FakeChecklistService()
+            );
+            ResponseEntity<List<LargeCatItemResponse>> response = controller.getAllItems("1");
+
+            assertThat(response).isNotNull();
+        }
     }
 
     @DisplayName("postItem()")
@@ -185,7 +197,10 @@ class LargeCatControllerTest {
 
         @Override
         public List<LargeCatItemResponse> findAllItems(Long checklistId) {
-            return null;
+            return List.of(
+                    new LargeCatItemResponse(1L, 1L, "test"),
+                    new LargeCatItemResponse(1L, 1L, "test")
+            );
         }
     }
 

--- a/src/test/java/org/swyp/weddy/domain/checklist/web/LargeCatControllerTest.java
+++ b/src/test/java/org/swyp/weddy/domain/checklist/web/LargeCatControllerTest.java
@@ -85,6 +85,11 @@ class LargeCatControllerTest {
         }
 
         @Override
+        public LargeCatItemResponse findItemWithSmallItems(Long checklistId, Long id) {
+            return null;
+        }
+
+        @Override
         public Long addItem(LargeCatItemAssignDto dto) {
             return 1L;
         }

--- a/src/test/java/org/swyp/weddy/domain/checklist/web/LargeCatControllerTest.java
+++ b/src/test/java/org/swyp/weddy/domain/checklist/web/LargeCatControllerTest.java
@@ -37,6 +37,20 @@ class LargeCatControllerTest {
         }
     }
 
+    @DisplayName("getAllItems()")
+    @Nested
+    class GetAllItemsTest {
+        @DisplayName("모든 대분류 항목 가져오기 요청을 받을 수 있다")
+        @Test
+        public void receive_get_all_large_items_message() {
+            LargeCatController controller = new LargeCatController(
+                    new FakeLargeCatService(),
+                    new FakeChecklistService()
+            );
+            controller.getAllItems("1");
+        }
+    }
+
     @DisplayName("postItem()")
     @Nested
     class PostItemTest {

--- a/src/test/java/org/swyp/weddy/domain/checklist/web/LargeCatControllerTest.java
+++ b/src/test/java/org/swyp/weddy/domain/checklist/web/LargeCatControllerTest.java
@@ -61,6 +61,18 @@ class LargeCatControllerTest {
 
             controller.postItem(request);
         }
+
+        @DisplayName("대분류 항목 추가 결과를 반환할 수 있다")
+        @Test
+        public void returns_post_large_item() {
+            LargeCatController controller = new LargeCatController(
+                    new FakeLargeCatService(),
+                    new FakeChecklistService()
+            );
+            LargeCatItemPostRequest request = new LargeCatItemPostRequest("1L", "test");
+
+            assertThat(controller.postItem(request)).isEqualTo(ResponseEntity.ok().build());
+        }
     }
 
     private static class FakeLargeCatService implements LargeCatService {

--- a/src/test/java/org/swyp/weddy/domain/checklist/web/LargeCatControllerTest.java
+++ b/src/test/java/org/swyp/weddy/domain/checklist/web/LargeCatControllerTest.java
@@ -1,0 +1,76 @@
+package org.swyp.weddy.domain.checklist.web;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.ResponseEntity;
+import org.swyp.weddy.domain.checklist.exception.LargeCatItemNotExistsException;
+import org.swyp.weddy.domain.checklist.service.ChecklistService;
+import org.swyp.weddy.domain.checklist.service.LargeCatService;
+import org.swyp.weddy.domain.checklist.service.dto.ChecklistDto;
+import org.swyp.weddy.domain.checklist.web.response.ChecklistResponse;
+import org.swyp.weddy.domain.checklist.web.response.LargeCatItemResponse;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class LargeCatControllerTest {
+
+    @DisplayName("getItem()")
+    @Nested
+    class getItemTest {
+        @DisplayName("대분류 항목 하나를 가져올 수 있다")
+        @Test
+        public void get_large_item() {
+            LargeCatController controller = new LargeCatController(
+                    new FakeLargeCatService(),
+                    new FakeChecklistService()
+            );
+            ResponseEntity<LargeCatItemResponse> response = controller.getItem("1", "1");
+            assertThat(response).isNotNull();
+        }
+
+        @DisplayName("대분류 항목이 없는 경우를 처리할 수 있다")
+        @Test
+        public void fail_to_get_large_item() {
+            LargeCatController controller = new LargeCatController(
+                    new FakeLargeCatService(),
+                    new FakeChecklistService()
+            );
+            Assertions.assertThrows(LargeCatItemNotExistsException.class, () -> {
+                controller.getItem("-1", "-1");
+            });
+        }
+    }
+
+    private static class FakeLargeCatService implements LargeCatService {
+        @Override
+        public LargeCatItemResponse findItem(Long checklistId, Long id) {
+            if (checklistId == -1L) {
+                return null;
+            }
+            return new LargeCatItemResponse(1L, 1L, "test");
+        }
+    }
+
+    private static class FakeChecklistService implements ChecklistService {
+
+        @Override
+        public Long assignChecklist(ChecklistDto dto) {
+            return 0L;
+        }
+
+        @Override
+        public boolean hasChecklist(ChecklistDto dto) {
+            return false;
+        }
+
+        @Override
+        public ChecklistResponse findChecklist(ChecklistDto dto) {
+            if (dto.getMemberId().equals("-1")) {
+                return new ChecklistResponse(-1L, "1L", 100);
+            }
+            return new ChecklistResponse(1L, "1L", 100);
+        }
+    }
+}

--- a/src/test/java/org/swyp/weddy/domain/checklist/web/LargeCatControllerTest.java
+++ b/src/test/java/org/swyp/weddy/domain/checklist/web/LargeCatControllerTest.java
@@ -118,6 +118,21 @@ class LargeCatControllerTest {
 
             controller.deleteItem(request);
         }
+
+        @DisplayName("대분류 항목 삭제 결과를 반환할 수 있다")
+        @Test
+        public void returns_delete_large_item() {
+            LargeCatController controller = new LargeCatController(
+                    new FakeLargeCatService(),
+                    new FakeChecklistService()
+            );
+            String memberId = "1";
+            String itemId = "1";
+
+            LargeCatItemDeleteRequest request = new LargeCatItemDeleteRequest(memberId, itemId);
+
+            assertThat(controller.deleteItem(request)).isEqualTo(ResponseEntity.ok().build());
+        }
     }
 
     private static class FakeLargeCatService implements LargeCatService {

--- a/src/test/java/org/swyp/weddy/domain/checklist/web/LargeCatControllerTest.java
+++ b/src/test/java/org/swyp/weddy/domain/checklist/web/LargeCatControllerTest.java
@@ -8,6 +8,7 @@ import org.swyp.weddy.domain.checklist.service.ChecklistService;
 import org.swyp.weddy.domain.checklist.service.LargeCatService;
 import org.swyp.weddy.domain.checklist.service.dto.ChecklistDto;
 import org.swyp.weddy.domain.checklist.service.dto.LargeCatItemAssignDto;
+import org.swyp.weddy.domain.checklist.service.dto.LargeCatItemDeleteDto;
 import org.swyp.weddy.domain.checklist.service.dto.LargeCatItemEditDto;
 import org.swyp.weddy.domain.checklist.web.request.LargeCatItemEditRequest;
 import org.swyp.weddy.domain.checklist.web.request.LargeCatItemPostRequest;
@@ -124,6 +125,11 @@ class LargeCatControllerTest {
         @Override
         public Long editItem(LargeCatItemEditDto dto) {
             return 1L;
+        }
+
+        @Override
+        public Long deleteItem(LargeCatItemDeleteDto dto) {
+            return 0L;
         }
     }
 

--- a/src/test/java/org/swyp/weddy/domain/checklist/web/LargeCatControllerTest.java
+++ b/src/test/java/org/swyp/weddy/domain/checklist/web/LargeCatControllerTest.java
@@ -196,6 +196,11 @@ class LargeCatControllerTest {
         }
 
         @Override
+        public Long deleteItemWithSmallItems(LargeCatItemDeleteDto dto) {
+            return 0L;
+        }
+
+        @Override
         public List<LargeCatItemResponse> findAllItems(Long checklistId) {
             return List.of(
                     new LargeCatItemResponse(1L, 1L, "test"),

--- a/src/test/java/org/swyp/weddy/domain/checklist/web/LargeCatControllerTest.java
+++ b/src/test/java/org/swyp/weddy/domain/checklist/web/LargeCatControllerTest.java
@@ -1,11 +1,9 @@
 package org.swyp.weddy.domain.checklist.web;
 
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.ResponseEntity;
-import org.swyp.weddy.domain.checklist.exception.LargeCatItemNotExistsException;
 import org.swyp.weddy.domain.checklist.service.ChecklistService;
 import org.swyp.weddy.domain.checklist.service.LargeCatService;
 import org.swyp.weddy.domain.checklist.service.dto.ChecklistDto;
@@ -30,18 +28,6 @@ class LargeCatControllerTest {
             );
             ResponseEntity<LargeCatItemResponse> response = controller.getItem("1", "1");
             assertThat(response).isNotNull();
-        }
-
-        @DisplayName("대분류 항목이 없는 경우를 처리할 수 있다")
-        @Test
-        public void fail_to_get_large_item() {
-            LargeCatController controller = new LargeCatController(
-                    new FakeLargeCatService(),
-                    new FakeChecklistService()
-            );
-            Assertions.assertThrows(LargeCatItemNotExistsException.class, () -> {
-                controller.getItem("-1", "-1");
-            });
         }
     }
 

--- a/src/test/java/org/swyp/weddy/domain/checklist/web/LargeCatControllerTest.java
+++ b/src/test/java/org/swyp/weddy/domain/checklist/web/LargeCatControllerTest.java
@@ -10,6 +10,7 @@ import org.swyp.weddy.domain.checklist.service.dto.ChecklistDto;
 import org.swyp.weddy.domain.checklist.service.dto.LargeCatItemAssignDto;
 import org.swyp.weddy.domain.checklist.service.dto.LargeCatItemDeleteDto;
 import org.swyp.weddy.domain.checklist.service.dto.LargeCatItemEditDto;
+import org.swyp.weddy.domain.checklist.web.request.LargeCatItemDeleteRequest;
 import org.swyp.weddy.domain.checklist.web.request.LargeCatItemEditRequest;
 import org.swyp.weddy.domain.checklist.web.request.LargeCatItemPostRequest;
 import org.swyp.weddy.domain.checklist.web.response.ChecklistResponse;
@@ -97,6 +98,25 @@ class LargeCatControllerTest {
             LargeCatItemEditRequest request = new LargeCatItemEditRequest(memberId, itemId, editedTitle);
 
             assertThat(controller.patchItem(request)).isEqualTo(ResponseEntity.ok().build());
+        }
+    }
+
+    @DisplayName("deleteItem()")
+    @Nested
+    class DeleteItemTest {
+        @DisplayName("대분류 항목 삭제 요청을 받을 수 있다")
+        @Test
+        public void receive_delete_large_item_message() {
+            LargeCatController controller = new LargeCatController(
+                    new FakeLargeCatService(),
+                    new FakeChecklistService()
+            );
+            String memberId = "1";
+            String itemId = "1";
+
+            LargeCatItemDeleteRequest request = new LargeCatItemDeleteRequest(memberId, itemId);
+
+            controller.deleteItem(request);
         }
     }
 

--- a/src/test/java/org/swyp/weddy/domain/checklist/web/LargeCatControllerTest.java
+++ b/src/test/java/org/swyp/weddy/domain/checklist/web/LargeCatControllerTest.java
@@ -86,7 +86,10 @@ class LargeCatControllerTest {
 
         @Override
         public LargeCatItemResponse findItemWithSmallItems(Long checklistId, Long id) {
-            return null;
+            if (checklistId == -1L) {
+                return null;
+            }
+            return new LargeCatItemResponse(1L, 1L, "test");
         }
 
         @Override

--- a/src/test/java/org/swyp/weddy/domain/checklist/web/LargeCatControllerTest.java
+++ b/src/test/java/org/swyp/weddy/domain/checklist/web/LargeCatControllerTest.java
@@ -8,6 +8,7 @@ import org.swyp.weddy.domain.checklist.service.ChecklistService;
 import org.swyp.weddy.domain.checklist.service.LargeCatService;
 import org.swyp.weddy.domain.checklist.service.dto.ChecklistDto;
 import org.swyp.weddy.domain.checklist.service.dto.LargeCatItemAssignDto;
+import org.swyp.weddy.domain.checklist.service.dto.LargeCatItemEditDto;
 import org.swyp.weddy.domain.checklist.web.request.LargeCatItemPostRequest;
 import org.swyp.weddy.domain.checklist.web.response.ChecklistResponse;
 import org.swyp.weddy.domain.checklist.web.response.LargeCatItemResponse;
@@ -80,6 +81,11 @@ class LargeCatControllerTest {
 
         @Override
         public Long addItem(LargeCatItemAssignDto dto) {
+            return 1L;
+        }
+
+        @Override
+        public Long editItem(LargeCatItemEditDto dto) {
             return 1L;
         }
     }

--- a/src/test/java/org/swyp/weddy/domain/checklist/web/LargeCatControllerTest.java
+++ b/src/test/java/org/swyp/weddy/domain/checklist/web/LargeCatControllerTest.java
@@ -10,6 +10,7 @@ import org.swyp.weddy.domain.checklist.service.ChecklistService;
 import org.swyp.weddy.domain.checklist.service.LargeCatService;
 import org.swyp.weddy.domain.checklist.service.dto.ChecklistDto;
 import org.swyp.weddy.domain.checklist.service.dto.LargeCatItemAssignDto;
+import org.swyp.weddy.domain.checklist.web.request.LargeCatItemPostRequest;
 import org.swyp.weddy.domain.checklist.web.response.ChecklistResponse;
 import org.swyp.weddy.domain.checklist.web.response.LargeCatItemResponse;
 
@@ -41,6 +42,24 @@ class LargeCatControllerTest {
             Assertions.assertThrows(LargeCatItemNotExistsException.class, () -> {
                 controller.getItem("-1", "-1");
             });
+        }
+    }
+
+    @DisplayName("postItem()")
+    @Nested
+    class postItemTest {
+        @DisplayName("대분류 항목 추가 요청을 받을 수 있다")
+        @Test
+        public void post_large_item() {
+            LargeCatController controller = new LargeCatController(
+                    new FakeLargeCatService(),
+                    new FakeChecklistService()
+            );
+            String memberId = "1L";
+            String title = "test";
+            LargeCatItemPostRequest request = new LargeCatItemPostRequest(memberId, title);
+
+            controller.postItem(request);
         }
     }
 

--- a/src/test/java/org/swyp/weddy/domain/checklist/web/LargeCatControllerTest.java
+++ b/src/test/java/org/swyp/weddy/domain/checklist/web/LargeCatControllerTest.java
@@ -9,6 +9,7 @@ import org.swyp.weddy.domain.checklist.exception.LargeCatItemNotExistsException;
 import org.swyp.weddy.domain.checklist.service.ChecklistService;
 import org.swyp.weddy.domain.checklist.service.LargeCatService;
 import org.swyp.weddy.domain.checklist.service.dto.ChecklistDto;
+import org.swyp.weddy.domain.checklist.service.dto.LargeCatItemAssignDto;
 import org.swyp.weddy.domain.checklist.web.response.ChecklistResponse;
 import org.swyp.weddy.domain.checklist.web.response.LargeCatItemResponse;
 
@@ -50,6 +51,11 @@ class LargeCatControllerTest {
                 return null;
             }
             return new LargeCatItemResponse(1L, 1L, "test");
+        }
+
+        @Override
+        public Long addItem(LargeCatItemAssignDto dto) {
+            return 1L;
         }
     }
 

--- a/src/test/java/org/swyp/weddy/domain/checklist/web/LargeCatControllerTest.java
+++ b/src/test/java/org/swyp/weddy/domain/checklist/web/LargeCatControllerTest.java
@@ -16,6 +16,8 @@ import org.swyp.weddy.domain.checklist.web.request.LargeCatItemPostRequest;
 import org.swyp.weddy.domain.checklist.web.response.ChecklistResponse;
 import org.swyp.weddy.domain.checklist.web.response.LargeCatItemResponse;
 
+import java.util.List;
+
 import static org.assertj.core.api.Assertions.assertThat;
 
 class LargeCatControllerTest {
@@ -165,6 +167,11 @@ class LargeCatControllerTest {
         @Override
         public Long deleteItem(LargeCatItemDeleteDto dto) {
             return 0L;
+        }
+
+        @Override
+        public List<LargeCatItemResponse> findAllItems(Long checklistId) {
+            return null;
         }
     }
 

--- a/src/test/java/org/swyp/weddy/domain/checklist/web/LargeCatControllerTest.java
+++ b/src/test/java/org/swyp/weddy/domain/checklist/web/LargeCatControllerTest.java
@@ -73,13 +73,29 @@ class LargeCatControllerTest {
                     new FakeLargeCatService(),
                     new FakeChecklistService()
             );
-            String memberId = "1L";
-            String itemId = "1L";
+            String memberId = "1";
+            String itemId = "1";
             String editedTitle = "test_revised";
 
             LargeCatItemEditRequest request = new LargeCatItemEditRequest(memberId, itemId, editedTitle);
 
             controller.patchItem(request);
+        }
+
+        @DisplayName("대분류 항목 수정 결과를 반환할 수 있다")
+        @Test
+        public void returns_patch_large_item() {
+            LargeCatController controller = new LargeCatController(
+                    new FakeLargeCatService(),
+                    new FakeChecklistService()
+            );
+            String memberId = "1";
+            String itemId = "1";
+            String editedTitle = "test_revised";
+
+            LargeCatItemEditRequest request = new LargeCatItemEditRequest(memberId, itemId, editedTitle);
+
+            assertThat(controller.patchItem(request)).isEqualTo(ResponseEntity.ok().build());
         }
     }
 


### PR DESCRIPTION
**현재 완료 상황**
- 대분류 항목 하나를 가져오는 서비스 로직을 구현합니다.
  - 컨트롤러 레이어에 추가할 필요는 없다고 의견 나눴으나, 동작 테스트 목적으로 API도 구현했습니다.
  - 로그인 기능 구현 시 추가된 필터 및 SecurityConfig로 인해, 로컬 테스트하려는 uri를 수동으로 추가하지 않으면 api 호출 자체가 되지 않습니다. 급하지는 않지만 적절한 처리가 필요해 보입니다.
  - 이전 체크리스트 로직 구현 시 사용한 테스트에서는 서비스 로직을 테스트할 때도 서비스 인터페이스에 대한 FakeService를 만들었지만, 실제로는 Mapper 인터페이스에 대한 FakeMapper만 필요합니다. 제 테스트 구현 방식으로 테스트를 짤 경우, 참고하면 좋을 것 같습니다 (2684074 커밋 참고)
- 대분류 항목 하나를 추가하는 API를 구현합니다.