### PR TITLE
API 로컬 테스트를 위하여 보안 필터 해제

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -23,6 +23,8 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-security'
 	implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
 
+	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.7.0'
+
 	implementation 'io.jsonwebtoken:jjwt-api:0.12.6'
 	runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.12.6'
 	runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.12.6'

--- a/src/main/java/org/swyp/weddy/common/config/SecurityConfig.java
+++ b/src/main/java/org/swyp/weddy/common/config/SecurityConfig.java
@@ -30,7 +30,7 @@ public class SecurityConfig {
                         sessionManagement.sessionCreationPolicy(SessionCreationPolicy.STATELESS)
                 )
                 .authorizeHttpRequests(auth -> auth
-                        .requestMatchers("/", "/home.html", "/h2-console/**", "/index.html","/auth/**", "/css/**", "/js/**", "/images/**").permitAll()
+                        .requestMatchers("/**").permitAll()
                         .anyRequest().authenticated()
                 )
                 // H2 콘솔 iframe 접근 허용

--- a/src/main/java/org/swyp/weddy/common/config/UriFilter.java
+++ b/src/main/java/org/swyp/weddy/common/config/UriFilter.java
@@ -25,6 +25,9 @@ public class UriFilter {
     public boolean isSkipUri(String uri) {
         return skipUriList.stream()
                 .anyMatch(skipUri -> {
+                    if (skipUri.equals("/**")) {
+                        return true;  // 모든 URI에 대해 true 반환
+                    }
                     // 루트 경로(/) 특별 처리
                     if (skipUri.trim().equals("/")) {
                         return uri.equals("/");

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -27,7 +27,7 @@ jwt:
   secret: 743AD29677E53D1E11DABE832D9DF13F288CCE9F1F414E32961E28AF4A11C8EAF525869BCF59FF66A35457A
 
 skip:
-  uris: "${SKIP_URIS:/h2,/auth/regenerate-token,/auth/login,/index.html,/}"
+  uris: "${SKIP_URIS:/**}"
 
 app:
   login-page-url: ${LOGIN_PAGE_URL:http://localhost:8080}


### PR DESCRIPTION
API 로컬 테스트를 위하여 보안 필터 해제했습니다.
1. Spring Security 접근을 모든 주소 허용으로 변경
2. JWT토큰 검증을 모든 주소 안하는 것으로 변경.
3. 스웨거 라이브러리 추가.

API문서 적용 PR먼저 머지한 뒤에
이 PR머지하면 될 것 같습니다.

