### PR TITLE
예외처리 시 응답코드를 ResponseEntity로 감싸서 처리한다

### DIFF
--- a/src/main/java/org/swyp/weddy/common/exception/ControllerAdvice.java
+++ b/src/main/java/org/swyp/weddy/common/exception/ControllerAdvice.java
@@ -1,5 +1,6 @@
 package org.swyp.weddy.common.exception;
 
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.swyp.weddy.domain.checklist.exception.ChecklistAlreadyAssignedException;
@@ -15,47 +16,56 @@ import org.swyp.weddy.domain.wiki.exception.WikiNotFoundException;
 public class ControllerAdvice {
 
     @ExceptionHandler(RuntimeException.class)
-    protected ErrorResponse handleBusinessException(final RuntimeException exception) {
-        return new ErrorResponse(ErrorCode.BAD_REQUEST);
+    protected ResponseEntity<ErrorResponse> handleBusinessException(final RuntimeException exception) {
+        ErrorResponse errorResponse = new ErrorResponse(ErrorCode.BAD_REQUEST);
+        return errorResponse.makeResponseEntity();
     }
 
     @ExceptionHandler(WikiNotFoundException.class)
-    protected ErrorResponse handleWikiNotFoundException(final WikiNotFoundException exception) {
-        return new ErrorResponse(exception.getErrorCode());
+    protected ResponseEntity<ErrorResponse> handleWikiNotFoundException(final WikiNotFoundException exception) {
+        ErrorResponse errorResponse = new ErrorResponse(exception.getErrorCode());
+        return errorResponse.makeResponseEntity();
     }
 
     @ExceptionHandler(ChecklistAlreadyAssignedException.class)
-    protected ErrorResponse handleChecklistAlreadyAssignedException(final ChecklistAlreadyAssignedException exception) {
-        return new ErrorResponse(exception.getErrorCode());
+    protected ResponseEntity<ErrorResponse> handleChecklistAlreadyAssignedException(final ChecklistAlreadyAssignedException exception) {
+        ErrorResponse errorResponse = new ErrorResponse(exception.getErrorCode());
+        return errorResponse.makeResponseEntity();
     }
 
     @ExceptionHandler(ChecklistNotExistsException.class)
-    protected ErrorResponse handleChecklistNotExistsException(final ChecklistNotExistsException exception) {
-        return new ErrorResponse(exception.getErrorCode());
+    protected ResponseEntity<ErrorResponse> handleChecklistNotExistsException(final ChecklistNotExistsException exception) {
+        ErrorResponse errorResponse = new ErrorResponse(exception.getErrorCode());
+        return errorResponse.makeResponseEntity();
     }
 
     @ExceptionHandler(LargeCatItemNotExistsException.class)
-    protected ErrorResponse handleLargeCatItemNotExistsException(final LargeCatItemNotExistsException exception) {
-        return new ErrorResponse(exception.getErrorCode());
+    protected ResponseEntity<ErrorResponse> handleLargeCatItemNotExistsException(final LargeCatItemNotExistsException exception) {
+        ErrorResponse errorResponse = new ErrorResponse(exception.getErrorCode());
+        return errorResponse.makeResponseEntity();
     }
 
     @ExceptionHandler(SmallCategoryItemNotExistsException.class)
-    protected ErrorResponse handleSmallCategoryItemNotExistsException(final SmallCategoryItemNotExistsException exception) {
-        return new ErrorResponse(exception.getErrorCode());
+    protected ResponseEntity<ErrorResponse> handleSmallCategoryItemNotExistsException(final SmallCategoryItemNotExistsException exception) {
+        ErrorResponse errorResponse = new ErrorResponse(exception.getErrorCode());
+        return errorResponse.makeResponseEntity();
     }
 
     @ExceptionHandler(SmallCategoryItemAddException.class)
-    protected ErrorResponse SmallCategoryItemAddException(final SmallCategoryItemAddException exception) {
-        return new ErrorResponse(exception.getErrorCode());
+    protected ResponseEntity<ErrorResponse> SmallCategoryItemAddException(final SmallCategoryItemAddException exception) {
+        ErrorResponse errorResponse = new ErrorResponse(exception.getErrorCode());
+        return errorResponse.makeResponseEntity();
     }
 
     @ExceptionHandler(SmallCategoryItemUpdateException.class)
-    protected ErrorResponse SmallCategoryItemUpdateException(final SmallCategoryItemUpdateException exception) {
-        return new ErrorResponse(exception.getErrorCode());
+    protected ResponseEntity<ErrorResponse> SmallCategoryItemUpdateException(final SmallCategoryItemUpdateException exception) {
+        ErrorResponse errorResponse = new ErrorResponse(exception.getErrorCode());
+        return errorResponse.makeResponseEntity();
     }
 
     @ExceptionHandler(SmallCategoryItemDeleteException.class)
-    protected ErrorResponse SmallCategoryItemDeleteException(final SmallCategoryItemDeleteException exception) {
-        return new ErrorResponse(exception.getErrorCode());
+    protected ResponseEntity<ErrorResponse> SmallCategoryItemDeleteException(final SmallCategoryItemDeleteException exception) {
+        ErrorResponse errorResponse = new ErrorResponse(exception.getErrorCode());
+        return errorResponse.makeResponseEntity();
     }
 }

--- a/src/main/java/org/swyp/weddy/common/exception/ControllerAdvice.java
+++ b/src/main/java/org/swyp/weddy/common/exception/ControllerAdvice.java
@@ -58,22 +58,4 @@ public class ControllerAdvice {
     protected ErrorResponse SmallCategoryItemDeleteException(final SmallCategoryItemDeleteException exception) {
         return new ErrorResponse(exception.getErrorCode());
     }
-
-    private static class ErrorResponse {
-        private final String code;
-        private final String reason;
-
-        private ErrorResponse(ErrorCode errorCode) {
-            this.code = errorCode.getCode();
-            this.reason = errorCode.getReason();
-        }
-
-        public String getCode() {
-            return this.code;
-        }
-
-        public String getReason() {
-            return this.reason;
-        }
-    }
 }

--- a/src/main/java/org/swyp/weddy/common/exception/ErrorResponse.java
+++ b/src/main/java/org/swyp/weddy/common/exception/ErrorResponse.java
@@ -1,5 +1,8 @@
 package org.swyp.weddy.common.exception;
 
+import org.springframework.http.HttpStatusCode;
+import org.springframework.http.ResponseEntity;
+
 class ErrorResponse {
     private final String code;
     private final String reason;
@@ -15,5 +18,14 @@ class ErrorResponse {
 
     public String getReason() {
         return this.reason;
+    }
+
+    public HttpStatusCode getHttpStatusCode() {
+        Integer code = Integer.valueOf(this.getCode());
+        return HttpStatusCode.valueOf(code);
+    }
+
+    public ResponseEntity<ErrorResponse> makeResponseEntity(HttpStatusCode httpStatusCode) {
+        return ResponseEntity.status(httpStatusCode).body(this);
     }
 }

--- a/src/main/java/org/swyp/weddy/common/exception/ErrorResponse.java
+++ b/src/main/java/org/swyp/weddy/common/exception/ErrorResponse.java
@@ -1,0 +1,19 @@
+package org.swyp.weddy.common.exception;
+
+class ErrorResponse {
+    private final String code;
+    private final String reason;
+
+    ErrorResponse(ErrorCode errorCode) {
+        this.code = errorCode.getCode();
+        this.reason = errorCode.getReason();
+    }
+
+    public String getCode() {
+        return this.code;
+    }
+
+    public String getReason() {
+        return this.reason;
+    }
+}

--- a/src/main/java/org/swyp/weddy/common/exception/ErrorResponse.java
+++ b/src/main/java/org/swyp/weddy/common/exception/ErrorResponse.java
@@ -1,8 +1,10 @@
 package org.swyp.weddy.common.exception;
 
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatusCode;
 import org.springframework.http.ResponseEntity;
 
+@Slf4j
 class ErrorResponse {
     private final String code;
     private final String reason;
@@ -22,7 +24,19 @@ class ErrorResponse {
 
     public HttpStatusCode getHttpStatusCode() {
         Integer code = Integer.valueOf(this.getCode());
-        return HttpStatusCode.valueOf(code);
+        try {
+            return HttpStatusCode.valueOf(code);
+        } catch (IllegalArgumentException e) {
+            log.error(
+                    "Cannot convert code into HttpStatusCode: {}. ErrorCode.code should be between 100 <= code <= 999",
+                    this.getCode(),
+                    e
+            );
+            throw new IllegalArgumentException(
+                    "Cannot convert code into HttpStatusCode: {}. ErrorCode.code should be between 100 <= code <= 999",
+                    e
+            );
+        }
     }
 
     public ResponseEntity<ErrorResponse> makeResponseEntity() {

--- a/src/main/java/org/swyp/weddy/common/exception/ErrorResponse.java
+++ b/src/main/java/org/swyp/weddy/common/exception/ErrorResponse.java
@@ -25,7 +25,8 @@ class ErrorResponse {
         return HttpStatusCode.valueOf(code);
     }
 
-    public ResponseEntity<ErrorResponse> makeResponseEntity(HttpStatusCode httpStatusCode) {
+    public ResponseEntity<ErrorResponse> makeResponseEntity() {
+        HttpStatusCode httpStatusCode = this.getHttpStatusCode();
         return ResponseEntity.status(httpStatusCode).body(this);
     }
 }

--- a/src/test/java/org/swyp/weddy/common/exception/ErrorResponseTest.java
+++ b/src/test/java/org/swyp/weddy/common/exception/ErrorResponseTest.java
@@ -1,0 +1,14 @@
+package org.swyp.weddy.common.exception;
+
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class ErrorResponseTest {
+    @DisplayName("ControllerAdvice 바깥에서 ErrorResponse 객체를 생성할 수 있다")
+    @Test
+    public void make_error_response_object() {
+        ErrorResponse errorResponse = new ErrorResponse(ErrorCode.BAD_REQUEST);
+        Assertions.assertThat(errorResponse).isNotNull();
+    }
+}

--- a/src/test/java/org/swyp/weddy/common/exception/ErrorResponseTest.java
+++ b/src/test/java/org/swyp/weddy/common/exception/ErrorResponseTest.java
@@ -31,8 +31,7 @@ class ErrorResponseTest {
         @Test
         public void make_response_entity_with_error_response_as_its_body() {
             ErrorResponse errorResponse = new ErrorResponse(ErrorCode.BAD_REQUEST);
-            HttpStatusCode httpStatusCode  = errorResponse.getHttpStatusCode();
-            ResponseEntity<ErrorResponse> responseEntity = errorResponse.makeResponseEntity(httpStatusCode);
+            ResponseEntity<ErrorResponse> responseEntity = errorResponse.makeResponseEntity();
             assertThat(responseEntity.getStatusCode().is4xxClientError()).isTrue();
             assertThat(responseEntity.getBody()).isNotNull();
         }

--- a/src/test/java/org/swyp/weddy/common/exception/ErrorResponseTest.java
+++ b/src/test/java/org/swyp/weddy/common/exception/ErrorResponseTest.java
@@ -1,18 +1,19 @@
 package org.swyp.weddy.common.exception;
 
-import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.HttpStatusCode;
 import org.springframework.http.ResponseEntity;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 class ErrorResponseTest {
     @DisplayName("ControllerAdvice 바깥에서 ErrorResponse 객체를 생성할 수 있다")
     @Test
     public void make_error_response_object() {
         ErrorResponse errorResponse = new ErrorResponse(ErrorCode.BAD_REQUEST);
-        Assertions.assertThat(errorResponse).isNotNull();
+        assertThat(errorResponse).isNotNull();
     }
 
     @DisplayName("ErrorResponse 내 정보를 가지고 ResponseEntity를 만들 수 있다")
@@ -25,7 +26,7 @@ class ErrorResponseTest {
             String code = errorResponse.getCode();
             Integer iCode = Integer.valueOf(code);
             HttpStatusCode httpStatusCode = HttpStatusCode.valueOf(iCode);
-            Assertions.assertThat(httpStatusCode.is4xxClientError()).isTrue();
+            assertThat(httpStatusCode.is4xxClientError()).isTrue();
         }
 
         @DisplayName("body를 ErrorResponse로 하는 ResponseEntity를 만들 수 있다")
@@ -36,8 +37,8 @@ class ErrorResponseTest {
             Integer iCode = Integer.valueOf(code);
             HttpStatusCode httpStatusCode = HttpStatusCode.valueOf(iCode);
             ResponseEntity<ErrorResponse> responseEntity = ResponseEntity.status(httpStatusCode).body(errorResponse);
-            Assertions.assertThat(responseEntity.getStatusCode().is4xxClientError()).isTrue();
-            Assertions.assertThat(responseEntity.getBody()).isNotNull();
+            assertThat(responseEntity.getStatusCode().is4xxClientError()).isTrue();
+            assertThat(responseEntity.getBody()).isNotNull();
         }
     }
 }

--- a/src/test/java/org/swyp/weddy/common/exception/ErrorResponseTest.java
+++ b/src/test/java/org/swyp/weddy/common/exception/ErrorResponseTest.java
@@ -1,5 +1,6 @@
 package org.swyp.weddy.common.exception;
 
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -35,5 +36,14 @@ class ErrorResponseTest {
             assertThat(responseEntity.getStatusCode().is4xxClientError()).isTrue();
             assertThat(responseEntity.getBody()).isNotNull();
         }
+    }
+
+    @DisplayName("code 값이 HttpStatusCode 범위 밖일 때 예외 처리할 수 있다")
+    @Test
+    public void handle_code_not_in_range() {
+        ErrorResponse invalidErrorResponse = new ErrorResponse(ErrorCode.TOKEN_EXPIRED);
+        Assertions.assertThrows(IllegalArgumentException.class, () -> {
+            invalidErrorResponse.getHttpStatusCode();
+        });
     }
 }

--- a/src/test/java/org/swyp/weddy/common/exception/ErrorResponseTest.java
+++ b/src/test/java/org/swyp/weddy/common/exception/ErrorResponseTest.java
@@ -2,7 +2,10 @@ package org.swyp.weddy.common.exception;
 
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpStatusCode;
+import org.springframework.http.ResponseEntity;
 
 class ErrorResponseTest {
     @DisplayName("ControllerAdvice 바깥에서 ErrorResponse 객체를 생성할 수 있다")
@@ -10,5 +13,31 @@ class ErrorResponseTest {
     public void make_error_response_object() {
         ErrorResponse errorResponse = new ErrorResponse(ErrorCode.BAD_REQUEST);
         Assertions.assertThat(errorResponse).isNotNull();
+    }
+
+    @DisplayName("ErrorResponse 내 정보를 가지고 ResponseEntity를 만들 수 있다")
+    @Nested
+    class convert2ResponseEntityTest {
+        @DisplayName("ErrorResponse의 code를 ResponseEntity용 코드값으로 변환할 수 있다")
+        @Test
+        public void convert_code_to_http_status() {
+            ErrorResponse errorResponse = new ErrorResponse(ErrorCode.BAD_REQUEST);
+            String code = errorResponse.getCode();
+            Integer iCode = Integer.valueOf(code);
+            HttpStatusCode httpStatusCode = HttpStatusCode.valueOf(iCode);
+            Assertions.assertThat(httpStatusCode.is4xxClientError()).isTrue();
+        }
+
+        @DisplayName("body를 ErrorResponse로 하는 ResponseEntity를 만들 수 있다")
+        @Test
+        public void make_response_entity_with_error_response_as_its_body() {
+            ErrorResponse errorResponse = new ErrorResponse(ErrorCode.BAD_REQUEST);
+            String code = errorResponse.getCode();
+            Integer iCode = Integer.valueOf(code);
+            HttpStatusCode httpStatusCode = HttpStatusCode.valueOf(iCode);
+            ResponseEntity<ErrorResponse> responseEntity = ResponseEntity.status(httpStatusCode).body(errorResponse);
+            Assertions.assertThat(responseEntity.getStatusCode().is4xxClientError()).isTrue();
+            Assertions.assertThat(responseEntity.getBody()).isNotNull();
+        }
     }
 }

--- a/src/test/java/org/swyp/weddy/common/exception/ErrorResponseTest.java
+++ b/src/test/java/org/swyp/weddy/common/exception/ErrorResponseTest.java
@@ -23,9 +23,7 @@ class ErrorResponseTest {
         @Test
         public void convert_code_to_http_status() {
             ErrorResponse errorResponse = new ErrorResponse(ErrorCode.BAD_REQUEST);
-            String code = errorResponse.getCode();
-            Integer iCode = Integer.valueOf(code);
-            HttpStatusCode httpStatusCode = HttpStatusCode.valueOf(iCode);
+            HttpStatusCode httpStatusCode  = errorResponse.getHttpStatusCode();
             assertThat(httpStatusCode.is4xxClientError()).isTrue();
         }
 
@@ -33,10 +31,8 @@ class ErrorResponseTest {
         @Test
         public void make_response_entity_with_error_response_as_its_body() {
             ErrorResponse errorResponse = new ErrorResponse(ErrorCode.BAD_REQUEST);
-            String code = errorResponse.getCode();
-            Integer iCode = Integer.valueOf(code);
-            HttpStatusCode httpStatusCode = HttpStatusCode.valueOf(iCode);
-            ResponseEntity<ErrorResponse> responseEntity = ResponseEntity.status(httpStatusCode).body(errorResponse);
+            HttpStatusCode httpStatusCode  = errorResponse.getHttpStatusCode();
+            ResponseEntity<ErrorResponse> responseEntity = errorResponse.makeResponseEntity(httpStatusCode);
             assertThat(responseEntity.getStatusCode().is4xxClientError()).isTrue();
             assertThat(responseEntity.getBody()).isNotNull();
         }


### PR DESCRIPTION
- ControllerAdvice에서 ErrorResponse 대신 ResponsEntity<ErrorResponse> 타입 객체를 반환하도록 변경합니다.
- 변경 후 예외처리 시 반환하는 객체는
  - ErrorResponse의 code를 HttpStatusCode로,
  - ResponsEntity의 body를 ErrorResponse 객체로 가집니다.
- ResponsEntity의 HttpStatusCode가 가질 수 있는 범위는 100 <= code 값 <= 999 입니다. 따라서 기존 구현의 ErrorCode에서 code 값이 이 범위를 벗어나는 경우 값 변경이 필요합니다.
  - `TOKEN_EXPIRED("4011", "JWT 토큰이 만료됨")`