### PR TITLE
예외처리 시 응답 객체 body에 httpStatusCode 제외

### DIFF
--- a/src/main/java/org/swyp/weddy/common/exception/ErrorResponse.java
+++ b/src/main/java/org/swyp/weddy/common/exception/ErrorResponse.java
@@ -22,7 +22,7 @@ class ErrorResponse {
         return this.reason;
     }
 
-    public HttpStatusCode getHttpStatusCode() {
+    public HttpStatusCode convertHttpStatusCode() {
         Integer code = Integer.valueOf(this.getCode());
         try {
             return HttpStatusCode.valueOf(code);
@@ -40,7 +40,7 @@ class ErrorResponse {
     }
 
     public ResponseEntity<ErrorResponse> makeResponseEntity() {
-        HttpStatusCode httpStatusCode = this.getHttpStatusCode();
+        HttpStatusCode httpStatusCode = this.convertHttpStatusCode();
         return ResponseEntity.status(httpStatusCode).body(this);
     }
 }

--- a/src/test/java/org/swyp/weddy/common/exception/ErrorResponseTest.java
+++ b/src/test/java/org/swyp/weddy/common/exception/ErrorResponseTest.java
@@ -1,5 +1,7 @@
 package org.swyp.weddy.common.exception;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -35,6 +37,22 @@ class ErrorResponseTest {
             ResponseEntity<ErrorResponse> responseEntity = errorResponse.makeResponseEntity();
             assertThat(responseEntity.getStatusCode().is4xxClientError()).isTrue();
             assertThat(responseEntity.getBody()).isNotNull();
+        }
+
+        @DisplayName("body에 HttpStatusCode를 포함하지 않는다")
+        @Test
+        public void remove_http_status_code_from_error_response_body() throws JsonProcessingException {
+            ErrorResponse errorResponse = new ErrorResponse(ErrorCode.BAD_REQUEST);
+            ResponseEntity<ErrorResponse> responseEntity = errorResponse.makeResponseEntity();
+
+            ObjectMapper objectMapper = new ObjectMapper();
+            String s = objectMapper.writeValueAsString(responseEntity.getBody());
+            assertThat(s).isEqualTo("{" +
+                    "\"code\":\"400\"," +
+                    "\"reason\":\"잘못된 요청\"," +
+                    "\"httpStatusCode\":\"BAD_REQUEST\"" +
+                    "}");
+            assertThat(s.contains("httpStatusCode")).isTrue();
         }
     }
 

--- a/src/test/java/org/swyp/weddy/common/exception/ErrorResponseTest.java
+++ b/src/test/java/org/swyp/weddy/common/exception/ErrorResponseTest.java
@@ -49,10 +49,9 @@ class ErrorResponseTest {
             String s = objectMapper.writeValueAsString(responseEntity.getBody());
             assertThat(s).isEqualTo("{" +
                     "\"code\":\"400\"," +
-                    "\"reason\":\"잘못된 요청\"," +
-                    "\"httpStatusCode\":\"BAD_REQUEST\"" +
+                    "\"reason\":\"잘못된 요청\"" +
                     "}");
-            assertThat(s.contains("httpStatusCode")).isTrue();
+            assertThat(s.contains("httpStatusCode")).isFalse();
         }
     }
 

--- a/src/test/java/org/swyp/weddy/common/exception/ErrorResponseTest.java
+++ b/src/test/java/org/swyp/weddy/common/exception/ErrorResponseTest.java
@@ -26,7 +26,7 @@ class ErrorResponseTest {
         @Test
         public void convert_code_to_http_status() {
             ErrorResponse errorResponse = new ErrorResponse(ErrorCode.BAD_REQUEST);
-            HttpStatusCode httpStatusCode  = errorResponse.getHttpStatusCode();
+            HttpStatusCode httpStatusCode  = errorResponse.convertHttpStatusCode();
             assertThat(httpStatusCode.is4xxClientError()).isTrue();
         }
 
@@ -61,7 +61,7 @@ class ErrorResponseTest {
     public void handle_code_not_in_range() {
         ErrorResponse invalidErrorResponse = new ErrorResponse(ErrorCode.TOKEN_EXPIRED);
         Assertions.assertThrows(IllegalArgumentException.class, () -> {
-            invalidErrorResponse.getHttpStatusCode();
+            invalidErrorResponse.convertHttpStatusCode();
         });
     }
 }


### PR DESCRIPTION
ErrorResponse에 httpStatusCode 필드가 없더라도, getter를 정의하면
ResponseEntity의 body에 httpStatusCode 필드가 포함됩니다
```
{
  "code": "400",
  "reason": "잘못된 요청",
  "httpStatusCode": "BAD_REQUEST"
}
```

메서드명을 바꿔서 해당 필드가 body에 포함되지 않도록 합니다