### PR TITLE
환경변수로 인한 contextLoad() 테스트 실패를 해결한다

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -44,8 +44,19 @@ dependencies {
 
 tasks.named('test') {
 	useJUnitPlatform()
+
+	environment "JWT_SECRET", makeDummyJwtToken()
+	environment "KAKAO_CLIENT_ID", "dummy"
+	environment "KAKAO_REDIRECT_URL", "dummy"
 }
 
 jar {
 	enabled = false // plain JAR 생성을 방지
+}
+
+def makeDummyJwtToken() {
+	def header = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9"
+	def payload = "eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ"
+	def signature = "SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c"
+	return header + "." + payload + "." + signature
 }

--- a/build.gradle
+++ b/build.gradle
@@ -45,18 +45,11 @@ dependencies {
 tasks.named('test') {
 	useJUnitPlatform()
 
-	environment "JWT_SECRET", makeDummyJwtToken()
+	environment "JWT_SECRET", "dummyfor64bytesSecretKeydummyfor"
 	environment "KAKAO_CLIENT_ID", "dummy"
 	environment "KAKAO_REDIRECT_URL", "dummy"
 }
 
 jar {
 	enabled = false // plain JAR 생성을 방지
-}
-
-def makeDummyJwtToken() {
-	def header = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9"
-	def payload = "eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ"
-	def signature = "SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c"
-	return header + "." + payload + "." + signature
 }


### PR DESCRIPTION
 - application.yaml에 등록된 다음 세 환경변수값이 설정되지 않아서 gradle test task가 실패한다: JWT_SECRET, KAKAO_CLIENT_ID, KAKAO_REDIRECT_URL
 - gradle build task 실행 시 test task가 자동으로 실행되기 때문에 추후 문제 발생이 예상된다
 - 환경변수를 따로 설정해주지 않아도 gradle test가 성공하도록 gradle test task 실행 시에 임시 환경변수를 추가해서 해결한다