### PR TITLE
swagger API 요청 시 발생하는 CORS 에러 처리

### DIFF
--- a/lombok.config
+++ b/lombok.config
@@ -1,0 +1,1 @@
+lombok.copyableAnnotations += org.springframework.beans.factory.annotation.Value

--- a/src/main/java/org/swyp/weddy/common/config/CorsConfig.java
+++ b/src/main/java/org/swyp/weddy/common/config/CorsConfig.java
@@ -11,8 +11,11 @@ import java.util.Arrays;
 
 @Configuration
 public class CorsConfig {
-    @Value("${cors.uris}")
-    private String corsUris;
+    private final String corsUris;
+
+    public CorsConfig(@Value("${cors.uris}") String corsUris) {
+        this.corsUris = corsUris;
+    }
 
     @Bean
     CorsConfigurationSource corsConfigSource() {

--- a/src/main/java/org/swyp/weddy/common/config/OpenApiConfig.java
+++ b/src/main/java/org/swyp/weddy/common/config/OpenApiConfig.java
@@ -1,0 +1,25 @@
+package org.swyp.weddy.common.config;
+
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.servers.Server;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class OpenApiConfig {
+    @Bean
+    public OpenAPI openAPI() {
+        Info info = new Info()
+                .title("Weddy API Document")
+                .version("1.0")
+                .description(
+                        "결혼 준비를 도와주는 웹 애플리케이션 API 문서\n")
+                .contact(new io.swagger.v3.oas.models.info.Contact().email("swypteam9@gmail.com"));
+
+        return new OpenAPI()
+                .addServersItem(new Server().url("http://localhost:8080"))
+                .addServersItem(new Server().url("https://your-weddy.pe.kr"))
+                .info(info);
+    }
+}

--- a/src/test/java/org/swyp/weddy/common/config/CorsConfigTest.java
+++ b/src/test/java/org/swyp/weddy/common/config/CorsConfigTest.java
@@ -11,7 +11,7 @@ class CorsConfigTest {
     @DisplayName("cors 설정에 필요한 객체를 생성할 수 있다")
     @Test
     public void make_cors_config_bean() {
-        CorsConfig corsConfig = new CorsConfig();
+        CorsConfig corsConfig = new CorsConfig("http://localhost:3000");
         CorsConfigurationSource corsConfigSrc = corsConfig.corsConfigSource();
         assertNotNull(corsConfigSrc);
     }


### PR DESCRIPTION
1. 배포된 앱의 swagger에서 api 호출 시 발생하는 cors 에러를 해결합니다.
2. 깨지는 CorsConfig 테스트가 통과하도록 고칩니다.
- 원인
  - cors uri 목록을 환경변수로 빼내면서 @Value를 써서 값을 가져오도록 바뀌었는데
  - 이 변경으로 기존 corsConfig 테스트에 문제가 생겼습니다.
  - 왜냐면 단위 테스트에선 spring application context를 부르지 않고, 그래서 @Value로 선언한 cors uri 목록 값을 가져오지 않거든요.
- 해결
  - JWT_SECRET 환경변수를 처리한 방식으로 build.gradle에 추가하는 방법도 있지만, 더 깔끔한 방법을 찾아봤습니다.
  - spring application context를 불러오는 테스트라면 환경변수 값을 설정해야 하겠지만, 그렇지 않은 단위 테스트에서까지 환경변수를 설정하면 해당 테스트가 불필요하게 많은 정보를 알고 있어야 하는 것 같아서요.
  - required arguments constructor에서 환경변수 값을 초기화할 수 있게 바꿔서
  - spring application context를 부르지 않는 테스트에서 환경변수 값을 직접 설정할 수 있도록 바꿨습니다.
- 의견
  - 기존에 @Value를 쓰는 방식을 이 PR에서 변경한 방식으로 바꾸는 건 어떨까 합니다.
- 참고자료: https://www.podo-dev.com/blogs/230