### PR TITLE
소분류 항목 이동기능 구현

### DIFF
--- a/src/main/java/org/swyp/weddy/domain/checklist/dao/SmallCatMapper.java
+++ b/src/main/java/org/swyp/weddy/domain/checklist/dao/SmallCatMapper.java
@@ -13,6 +13,7 @@ public interface SmallCatMapper {
     List<SmallCatItemPreview> selectItemPreviews(@Param("checklistId")Long checklistId, @Param("largeCatItemId")Long largeCatItemId);
     SmallCatItem selectItem(@Param("checklistId")Long checklistId, @Param("largeCatItemId")Long largeCatItemId, @Param("smallCatItemId")Long smallCatItemId);
 
+    List<SmallCatItem> selectItems(@Param("checklistId")Long checklistId, @Param("largeCatItemId")Long largeCatItemId);
     Long insertItem(SmallCatItem smallCatItem);
 
     int updateItem(SmallCatItem smallCatItem);
@@ -20,7 +21,6 @@ public interface SmallCatMapper {
     int deleteItem(@Param("largeCatItemId")Long largeCatItemId, @Param("smallCatItemId")Long smallCatItemId);
     int deleteAllItems(@Param("checklistId")Long checklistId, @Param("largeCatItemId")Long largeCatItemId);
 
-
-
+    int moveItem(SmallCatItem item);
 
 }

--- a/src/main/java/org/swyp/weddy/domain/checklist/dao/SmallCatMapper.java
+++ b/src/main/java/org/swyp/weddy/domain/checklist/dao/SmallCatMapper.java
@@ -12,8 +12,6 @@ public interface SmallCatMapper {
 
     List<SmallCatItemPreview> selectItemPreviews(@Param("checklistId")Long checklistId, @Param("largeCatItemId")Long largeCatItemId);
     SmallCatItem selectItem(@Param("checklistId")Long checklistId, @Param("largeCatItemId")Long largeCatItemId, @Param("smallCatItemId")Long smallCatItemId);
-
-    List<SmallCatItem> selectItems(@Param("checklistId")Long checklistId, @Param("largeCatItemId")Long largeCatItemId);
     Long insertItem(SmallCatItem smallCatItem);
 
     int updateItem(SmallCatItem smallCatItem);

--- a/src/main/java/org/swyp/weddy/domain/checklist/entity/SmallCatItem.java
+++ b/src/main/java/org/swyp/weddy/domain/checklist/entity/SmallCatItem.java
@@ -3,10 +3,15 @@ package org.swyp.weddy.domain.checklist.entity;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
+import lombok.extern.slf4j.Slf4j;
 import org.swyp.weddy.domain.checklist.service.dto.SmallCatItemDto;
+import org.swyp.weddy.domain.checklist.service.dto.SmallCatItemMoveDto;
 
+import java.util.ArrayList;
 import java.util.Date;
+import java.util.List;
 
+@Slf4j
 @Getter
 @AllArgsConstructor
 @Builder
@@ -20,6 +25,7 @@ public class SmallCatItem {
     private String body;
     private String statusName;
     private Long amount;
+    private Long sequence;
 
     public static SmallCatItem from(SmallCatItemDto dto) {
         return new SmallCatItem(
@@ -30,7 +36,50 @@ public class SmallCatItem {
                 dto.getAssigneeName(),
                 dto.getBody(),
                 dto.getStatusName(),
-                dto.getAmount()
+                dto.getAmount(),
+                null
         );
+    }
+
+    public static List<SmallCatItem> ofMove(List<SmallCatItem> itemsBeforeMove, SmallCatItemMoveDto dto) {
+
+        logItems(itemsBeforeMove);
+
+        List<Long> sequences = dto.getSmallCatItemIds();
+        ArrayList<SmallCatItem> itemsAfterMove = new ArrayList<>(sequences.size());
+
+        for (long i=0; i<sequences.size(); i++){
+            SmallCatItem movedItem =
+                    SmallCatItem.builder()
+                    .id(sequences.get((int) i))
+                    .largeCatItemId(dto.getLargeCatItemId())
+                    .sequence((i))
+                    .build();
+
+            itemsAfterMove.add(movedItem);
+        }
+
+        return itemsAfterMove;
+    }
+
+    private static void logItems(List<SmallCatItem> itemsBeforeMove) {
+        for (SmallCatItem smallCatItem : itemsBeforeMove) {
+            log.info("Items before move: {}", smallCatItem);
+        }
+    }
+
+    @Override
+    public String toString() {
+        return "SmallCatItem{" +
+                "id=" + id +
+                ", largeCatItemId=" + largeCatItemId +
+                ", title='" + title + '\'' +
+                ", dueDate=" + dueDate +
+                ", assigneeName='" + assigneeName + '\'' +
+                ", body='" + body + '\'' +
+                ", statusName='" + statusName + '\'' +
+                ", amount=" + amount +
+                ", sequence=" + sequence +
+                '}';
     }
 }

--- a/src/main/java/org/swyp/weddy/domain/checklist/entity/SmallCatItem.java
+++ b/src/main/java/org/swyp/weddy/domain/checklist/entity/SmallCatItem.java
@@ -41,9 +41,7 @@ public class SmallCatItem {
         );
     }
 
-    public static List<SmallCatItem> ofMove(List<SmallCatItem> itemsBeforeMove, SmallCatItemMoveDto dto) {
-
-        logItems(itemsBeforeMove);
+    public static List<SmallCatItem> ofMove(SmallCatItemMoveDto dto) {
 
         List<Long> sequences = dto.getSmallCatItemIds();
         ArrayList<SmallCatItem> itemsAfterMove = new ArrayList<>(sequences.size());
@@ -60,26 +58,5 @@ public class SmallCatItem {
         }
 
         return itemsAfterMove;
-    }
-
-    private static void logItems(List<SmallCatItem> itemsBeforeMove) {
-        for (SmallCatItem smallCatItem : itemsBeforeMove) {
-            log.info("Items before move: {}", smallCatItem);
-        }
-    }
-
-    @Override
-    public String toString() {
-        return "SmallCatItem{" +
-                "id=" + id +
-                ", largeCatItemId=" + largeCatItemId +
-                ", title='" + title + '\'' +
-                ", dueDate=" + dueDate +
-                ", assigneeName='" + assigneeName + '\'' +
-                ", body='" + body + '\'' +
-                ", statusName='" + statusName + '\'' +
-                ", amount=" + amount +
-                ", sequence=" + sequence +
-                '}';
     }
 }

--- a/src/main/java/org/swyp/weddy/domain/checklist/entity/SmallCatItemPreview.java
+++ b/src/main/java/org/swyp/weddy/domain/checklist/entity/SmallCatItemPreview.java
@@ -17,4 +17,6 @@ public class SmallCatItemPreview {
     private Date dueDate;
     private String assigneeName;
     private String statusName;
+    private Long sequence;
+
 }

--- a/src/main/java/org/swyp/weddy/domain/checklist/service/FakeSmallCatService.java
+++ b/src/main/java/org/swyp/weddy/domain/checklist/service/FakeSmallCatService.java
@@ -1,6 +1,7 @@
 package org.swyp.weddy.domain.checklist.service;
 
 import org.swyp.weddy.domain.checklist.service.dto.SmallCatItemDto;
+import org.swyp.weddy.domain.checklist.service.dto.SmallCatItemMoveDto;
 import org.swyp.weddy.domain.checklist.web.response.SmallCatItemPreviewResponse;
 import org.swyp.weddy.domain.checklist.web.response.SmallCatItemResponse;
 
@@ -43,6 +44,11 @@ public class FakeSmallCatService implements SmallCatService {
 
     @Override
     public boolean deleteAll(Long checklistId, Long largeCatItemId) {
+        return false;
+    }
+
+    @Override
+    public boolean moveItem(SmallCatItemMoveDto dto) {
         return false;
     }
 }

--- a/src/main/java/org/swyp/weddy/domain/checklist/service/SmallCatService.java
+++ b/src/main/java/org/swyp/weddy/domain/checklist/service/SmallCatService.java
@@ -1,6 +1,7 @@
 package org.swyp.weddy.domain.checklist.service;
 
 import org.swyp.weddy.domain.checklist.service.dto.SmallCatItemDto;
+import org.swyp.weddy.domain.checklist.service.dto.SmallCatItemMoveDto;
 import org.swyp.weddy.domain.checklist.web.response.SmallCatItemPreviewResponse;
 import org.swyp.weddy.domain.checklist.web.response.SmallCatItemResponse;
 
@@ -8,11 +9,12 @@ import java.util.List;
 
 public interface SmallCatService {
 
-    List<SmallCatItemPreviewResponse> findItemPreviews(Long checklistId, Long largeCatItemId); //Long checklistId, Long largeCatId);
+    List<SmallCatItemPreviewResponse> findItemPreviews(Long checklistId, Long largeCatItemId);
     SmallCatItemResponse findItem(Long checklistId, Long largeCatItemId, Long smallCatItemId);
 
-    Long addItem(SmallCatItemDto dto);//Long checklistId, Long largeCatId
-    boolean editItem(SmallCatItemDto dto); //Long checklistId, Long largeCatId, Long smallCatId);
-    boolean deleteItem(Long checklistId, Long largeCatItemId, Long smallCatItemId); //Long checklistId, Long largeCatId, Long smallCatId);
-    boolean deleteAll(Long checklistId, Long largeCatItemId);  //Long checklistId, Long largeCatId,
+    Long addItem(SmallCatItemDto dto);
+    boolean editItem(SmallCatItemDto dto);
+    boolean deleteItem(Long checklistId, Long largeCatItemId, Long smallCatItemId);
+    boolean deleteAll(Long checklistId, Long largeCatItemId);
+    boolean moveItem(SmallCatItemMoveDto dto);
 }

--- a/src/main/java/org/swyp/weddy/domain/checklist/service/SmallCatServiceImpl.java
+++ b/src/main/java/org/swyp/weddy/domain/checklist/service/SmallCatServiceImpl.java
@@ -12,6 +12,7 @@ import org.swyp.weddy.domain.checklist.exception.SmallCategoryItemDeleteExceptio
 import org.swyp.weddy.domain.checklist.exception.SmallCategoryItemNotExistsException;
 import org.swyp.weddy.domain.checklist.exception.SmallCategoryItemUpdateException;
 import org.swyp.weddy.domain.checklist.service.dto.SmallCatItemDto;
+import org.swyp.weddy.domain.checklist.service.dto.SmallCatItemMoveDto;
 import org.swyp.weddy.domain.checklist.web.response.SmallCatItemPreviewResponse;
 import org.swyp.weddy.domain.checklist.web.response.SmallCatItemResponse;
 
@@ -153,6 +154,27 @@ public class SmallCatServiceImpl implements SmallCatService {
         } catch (Exception e) {
             throw new SmallCategoryItemDeleteException(ErrorCode.DELETE_FAILED);
         }
+    }
+
+    @Transactional
+    @Override
+    public boolean moveItem(SmallCatItemMoveDto dto) {
+
+        if (dto.getSmallCatItemIds() == null || dto.getSmallCatItemIds().isEmpty()) {
+            throw new SmallCategoryItemNotExistsException(ErrorCode.NOT_EXISTS);
+        }
+
+        List<SmallCatItem> itemsBeforeMove = mapper.selectItems(dto.getChecklistId(), dto.getLargeCatItemId());
+        List<SmallCatItem> itemsAfterMove = SmallCatItem.ofMove(itemsBeforeMove, dto);
+
+        for (SmallCatItem item: itemsAfterMove) {
+            int updatedRows = mapper.moveItem(item);
+            if (updatedRows != 1) {
+                throw new SmallCategoryItemUpdateException(ErrorCode.UPDATE_FAILED);
+            }
+        }
+
+        return true;
     }
 
 }

--- a/src/main/java/org/swyp/weddy/domain/checklist/service/SmallCatServiceImpl.java
+++ b/src/main/java/org/swyp/weddy/domain/checklist/service/SmallCatServiceImpl.java
@@ -164,10 +164,8 @@ public class SmallCatServiceImpl implements SmallCatService {
             throw new SmallCategoryItemNotExistsException(ErrorCode.NOT_EXISTS);
         }
 
-        List<SmallCatItem> itemsBeforeMove = mapper.selectItems(dto.getChecklistId(), dto.getLargeCatItemId());
-        List<SmallCatItem> itemsAfterMove = SmallCatItem.ofMove(itemsBeforeMove, dto);
-
-        for (SmallCatItem item: itemsAfterMove) {
+        List<SmallCatItem> smallCatItems = SmallCatItem.ofMove(dto);
+        for (SmallCatItem item: smallCatItems) {
             int updatedRows = mapper.moveItem(item);
             if (updatedRows != 1) {
                 throw new SmallCategoryItemUpdateException(ErrorCode.UPDATE_FAILED);

--- a/src/main/java/org/swyp/weddy/domain/checklist/service/dto/SmallCatItemMoveDto.java
+++ b/src/main/java/org/swyp/weddy/domain/checklist/service/dto/SmallCatItemMoveDto.java
@@ -1,0 +1,26 @@
+package org.swyp.weddy.domain.checklist.service.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import org.swyp.weddy.domain.checklist.web.request.SmallCatItemMoveRequest;
+
+import java.util.List;
+
+@AllArgsConstructor
+@Getter
+@Builder
+public class SmallCatItemMoveDto {
+    private Long checklistId;
+    private Long largeCatItemId;
+    private List<Long> smallCatItemIds;
+
+
+    public static SmallCatItemMoveDto from(SmallCatItemMoveRequest request) {
+        return new SmallCatItemMoveDto(
+                request.getChecklistId(),
+                request.getLargeCatItemId(),
+                request.getSmallCatItemIds()
+        );
+    }
+}

--- a/src/main/java/org/swyp/weddy/domain/checklist/web/SmallCatController.java
+++ b/src/main/java/org/swyp/weddy/domain/checklist/web/SmallCatController.java
@@ -5,6 +5,8 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import org.swyp.weddy.domain.checklist.service.SmallCatService;
 import org.swyp.weddy.domain.checklist.service.dto.SmallCatItemDto;
+import org.swyp.weddy.domain.checklist.service.dto.SmallCatItemMoveDto;
+import org.swyp.weddy.domain.checklist.web.request.SmallCatItemMoveRequest;
 import org.swyp.weddy.domain.checklist.web.request.SmallCatItemPatchRequest;
 import org.swyp.weddy.domain.checklist.web.request.SmallCatItemPostRequest;
 import org.swyp.weddy.domain.checklist.web.response.SmallCatItemPreviewResponse;
@@ -74,6 +76,15 @@ public class SmallCatController {
                                                   @RequestParam(name = "largeCatItemId") Long largeCatItemId) {
 
         boolean result = smallCatService.deleteAll(checklistId, largeCatItemId);
+
+        return ResponseEntity.ok().body(result);
+    }
+
+    @PatchMapping("/move-item")
+    public ResponseEntity<Boolean> moveItem( @RequestBody SmallCatItemMoveRequest request) {
+
+        SmallCatItemMoveDto dto = SmallCatItemMoveDto.from(request);
+        boolean result = smallCatService.moveItem(dto);
 
         return ResponseEntity.ok().body(result);
     }

--- a/src/main/java/org/swyp/weddy/domain/checklist/web/SmallCatController.java
+++ b/src/main/java/org/swyp/weddy/domain/checklist/web/SmallCatController.java
@@ -81,7 +81,7 @@ public class SmallCatController {
     }
 
     @PatchMapping("/move-item")
-    public ResponseEntity<Boolean> moveItem( @RequestBody SmallCatItemMoveRequest request) {
+    public ResponseEntity<Boolean> moveItem(@RequestBody SmallCatItemMoveRequest request) {
 
         SmallCatItemMoveDto dto = SmallCatItemMoveDto.from(request);
         boolean result = smallCatService.moveItem(dto);

--- a/src/main/java/org/swyp/weddy/domain/checklist/web/request/SmallCatItemMoveRequest.java
+++ b/src/main/java/org/swyp/weddy/domain/checklist/web/request/SmallCatItemMoveRequest.java
@@ -1,0 +1,16 @@
+package org.swyp.weddy.domain.checklist.web.request;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class SmallCatItemMoveRequest {
+    private Long checklistId;
+    private Long largeCatItemId;
+    private List<Long> smallCatItemIds;
+}

--- a/src/main/resources/mapper/SmallCatMapper.xml
+++ b/src/main/resources/mapper/SmallCatMapper.xml
@@ -31,20 +31,6 @@
            AND small.is_deleted = false;
     </select>
 
-    <!-- 모든 컬럼 조회 -->
-    <select id="selectItems" resultType="org.swyp.weddy.domain.checklist.entity.SmallCatItem">
-        SELECT small.id, small.large_category_item_id, small.title, small.due_date, assignee.name, small.body, status.name "status_name", small.amount, small.sequence
-        FROM small_category_item small
-        JOIN large_category_item large ON small.large_category_item_id = large.id
-        JOIN checklist ON large.checklist_id = checklist.id
-        JOIN small_category_item_assignee assignee ON small.assignee_id = assignee.id
-        JOIN small_category_item_status status ON small.status_id = status.id
-       WHERE checklist.id = #{checklistId}
-         AND large.id = #{largeCatItemId}
-         AND small.is_deleted = false
-    ORDER BY small.sequence ASC;
-    </select>
-
     <!-- 항목 추가 -->
     <insert id="insertItem" useGeneratedKeys="true" keyProperty="id">
         INSERT INTO small_category_item

--- a/src/main/resources/mapper/SmallCatMapper.xml
+++ b/src/main/resources/mapper/SmallCatMapper.xml
@@ -13,7 +13,8 @@
           JOIN small_category_item_status status ON small.status_id = status.id
          WHERE checklist.id = #{checklistId}
            AND large.id = #{largeCatItemId}
-           AND small.is_deleted = false;
+           AND small.is_deleted = false
+      ORDER BY small.sequence ASC;
     </select>
 
     <!-- 모든 컬럼 조회 -->
@@ -38,9 +39,10 @@
         JOIN checklist ON large.checklist_id = checklist.id
         JOIN small_category_item_assignee assignee ON small.assignee_id = assignee.id
         JOIN small_category_item_status status ON small.status_id = status.id
-        WHERE checklist.id = #{checklistId}
-        AND large.id = #{largeCatItemId}
-        AND small.is_deleted = false;
+       WHERE checklist.id = #{checklistId}
+         AND large.id = #{largeCatItemId}
+         AND small.is_deleted = false
+    ORDER BY small.sequence ASC;
     </select>
 
     <!-- 항목 추가 -->

--- a/src/main/resources/mapper/SmallCatMapper.xml
+++ b/src/main/resources/mapper/SmallCatMapper.xml
@@ -5,7 +5,7 @@
 
     <!-- 프리뷰 컬럼 조회 -->
     <select id="selectItemPreviews" resultType="org.swyp.weddy.domain.checklist.entity.SmallCatItemPreview">
-        SELECT small.id, small.large_category_item_id, small.title, small.due_date, assignee.name, status.name "status_name"
+        SELECT small.id, small.large_category_item_id, small.title, small.due_date, assignee.name, status.name "status_name", small.sequence
           FROM small_category_item small
           JOIN large_category_item large ON small.large_category_item_id = large.id
           JOIN checklist ON large.checklist_id = checklist.id
@@ -18,7 +18,7 @@
 
     <!-- 모든 컬럼 조회 -->
     <select id="selectItem" resultType="org.swyp.weddy.domain.checklist.entity.SmallCatItem">
-        SELECT small.id, small.large_category_item_id, small.title, small.due_date, assignee.name, small.body, status.name "status_name", small.amount
+        SELECT small.id, small.large_category_item_id, small.title, small.due_date, assignee.name, small.body, status.name "status_name", small.amount, small.sequence
           FROM small_category_item small
           JOIN large_category_item large ON small.large_category_item_id = large.id
           JOIN checklist ON large.checklist_id = checklist.id
@@ -28,6 +28,19 @@
            AND large.id = #{largeCatItemId}
            AND small.id = #{smallCatItemId}
            AND small.is_deleted = false;
+    </select>
+
+    <!-- 모든 컬럼 조회 -->
+    <select id="selectItems" resultType="org.swyp.weddy.domain.checklist.entity.SmallCatItem">
+        SELECT small.id, small.large_category_item_id, small.title, small.due_date, assignee.name, small.body, status.name "status_name", small.amount, small.sequence
+        FROM small_category_item small
+        JOIN large_category_item large ON small.large_category_item_id = large.id
+        JOIN checklist ON large.checklist_id = checklist.id
+        JOIN small_category_item_assignee assignee ON small.assignee_id = assignee.id
+        JOIN small_category_item_status status ON small.status_id = status.id
+        WHERE checklist.id = #{checklistId}
+        AND large.id = #{largeCatItemId}
+        AND small.is_deleted = false;
     </select>
 
     <!-- 항목 추가 -->
@@ -69,5 +82,14 @@
            SET is_deleted = true,
                updated_at = NOW()
          WHERE large_category_item_id = #{largeCatItemId};
+    </update>
+
+    <!-- 항목 이동 -->
+    <update id="moveItem" parameterType="org.swyp.weddy.domain.checklist.entity.SmallCatItem">
+        UPDATE small_category_item
+           SET sequence = #{sequence},
+               large_category_item_id = #{largeCatItemId},
+               updated_at = NOW()
+         WHERE id = #{id};
     </update>
 </mapper>

--- a/src/main/resources/sql/schema.sql
+++ b/src/main/resources/sql/schema.sql
@@ -48,6 +48,7 @@ CREATE TABLE `small_category_item`
     `body`                   text COMMENT 'store rich text in HTML format',
     `status_id`              bigint,
     `amount`                 bigint,
+    `sequence`               bigint,
     `created_at`             timestamp,
     `updated_at`             timestamp,
     `is_deleted`             bool

--- a/src/test/java/org/swyp/weddy/domain/checklist/service/SmallCatServiceTest.java
+++ b/src/test/java/org/swyp/weddy/domain/checklist/service/SmallCatServiceTest.java
@@ -265,7 +265,6 @@ class SmallCatServiceTest {
                     .largeCatItemId(largeCatItemId)
                     .smallCatItemIds(List.of(smallCatItemId))
                     .build();
-            when(smallCatMapper.selectItems(checklistId, largeCatItemId)).thenReturn(List.of());
             when(smallCatMapper.moveItem(any(SmallCatItem.class))).thenReturn(1);
 
             // when

--- a/src/test/java/org/swyp/weddy/domain/checklist/service/SmallCatServiceTest.java
+++ b/src/test/java/org/swyp/weddy/domain/checklist/service/SmallCatServiceTest.java
@@ -4,8 +4,6 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.swyp.weddy.domain.checklist.dao.SmallCatMapper;
 import org.swyp.weddy.domain.checklist.entity.SmallCatItem;
 import org.swyp.weddy.domain.checklist.entity.SmallCatItemPreview;
@@ -25,256 +23,219 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
 
 class SmallCatServiceTest {
+    private SmallCatService smallCatService;
+    private SmallCatMapper smallCatMapper;
+    private Long checklistId;
+    private Long largeCatItemId;
+    private Long smallCatItemId;
 
-    private static final Logger log = LoggerFactory.getLogger(SmallCatServiceTest.class);
+    @BeforeEach
+    void setUp() {
+        checklistId = 1L;
+        largeCatItemId = 1L;
+        smallCatItemId = 1L;
 
-    @DisplayName("예외처리 테스트")
+        smallCatMapper = mock(SmallCatMapper.class);
+        smallCatService = new SmallCatServiceImpl(smallCatMapper);
+    }
+
+    @DisplayName("조회 관련 테스트")
     @Nested
-    class ExceptionTest {
-        private SmallCatService smallCatServiceImpl = new SmallCatServiceImpl(new FakeMapper());
+    class SelectTests {
 
         @DisplayName("소분류 항목 1개 조회 실패시 예외처리")
         @Test
         void findItem_Exception_Test() {
-            assertThatThrownBy(() -> {
-                smallCatServiceImpl.findItem(1L, 1L, 1L);
-            }).isInstanceOf(SmallCategoryItemNotExistsException.class);
+            // given
+            when(smallCatMapper.selectItem(checklistId, largeCatItemId, smallCatItemId)).thenReturn(null);
+
+            // when & then
+            assertThatThrownBy(() -> smallCatService.findItem(checklistId, largeCatItemId, smallCatItemId))
+                    .isInstanceOf(SmallCategoryItemNotExistsException.class);
         }
-
-        @DisplayName("소분류 항목 1개 추가 실패시 예외처리")
-        @Test
-        void addItem_Exception_Test() {
-            assertThatThrownBy(() -> {
-                smallCatServiceImpl.addItem(new SmallCatItemDto(null, null, null, null, null, null, null, null, null));
-            }).isInstanceOf(SmallCategoryItemAddException.class);
-        }
-
-        @DisplayName("소분류 항목 1개 추가 실패시 예외처리")
-        @Test
-        void editItem_Exception_Test() {
-            //given
-            smallCatServiceImpl = new SmallCatServiceImpl(new FakeMapper() {
-                @Override
-                public SmallCatItem selectItem(Long checklistId, Long largeCatItemId, Long smallCatItemId) {
-                    return new SmallCatItem(null, null, null, null, null, null, null, null);
-                }
-            });
-
-            //when, then
-            assertThatThrownBy(() -> {
-                smallCatServiceImpl.editItem(new SmallCatItemDto(null, null, null, null, null, null, null, null, null));
-            }).isInstanceOf(SmallCategoryItemUpdateException.class);
-        }
-
-        @DisplayName("소분류 항목 1개 삭제 실패시 예외처리")
-        @Test
-        void deleteItem_Exception_Test() {
-            //given
-            smallCatServiceImpl = new SmallCatServiceImpl(new FakeMapper() {
-                @Override
-                public SmallCatItem selectItem(Long checklistId, Long largeCatItemId, Long smallCatItemId) {
-                    return new SmallCatItem(null, null, null, null, null, null, null, null);
-                }
-            });
-
-            //when, then
-            assertThatThrownBy(() -> {
-                smallCatServiceImpl.deleteItem(1L, 1L, 1L);
-            }).isInstanceOf(SmallCategoryItemDeleteException.class);
-        }
-
-        @DisplayName("소분류 항목 여러개 삭제 실패시 예외처리")
-        @Test
-        void deleteAll_Exception_Test() {
-            //given
-            smallCatServiceImpl = new SmallCatServiceImpl(new FakeMapper() {
-                @Override
-                public List<SmallCatItemPreview> selectItemPreviews(Long checklistId, Long largeCatItemId) {
-                    return List.of(new SmallCatItemPreview(null, null, null, null, null, null));
-                }
-            });
-
-            //when, then
-            assertThatThrownBy(() -> {
-                smallCatServiceImpl.deleteAll(1L, 1L);
-            }).isInstanceOf(SmallCategoryItemDeleteException.class);
-        }
-
-        @DisplayName("삭제대상 없을 시 true 반환")
-        @Test
-        void deleteAll_Return_True_If_Select_Empty_Test() {
-            //given
-            smallCatServiceImpl = new SmallCatServiceImpl(new FakeMapper());
-
-            //when, then
-            assertThat(smallCatServiceImpl.deleteAll(1L, 1L)).isTrue();
-        }
-    }
-
-    @DisplayName("서비스 로직 테스트")
-    @Nested
-    class ServiceTest {
-        Long checklistId;
-        Long largeCatItemId;
-        Long smallCatItemId;
-
-        private SmallCatService smallCatService;
-        private SmallCatMapper smallCatMapper;
-
-        @BeforeEach
-        void setUp(){
-            checklistId = 1L;
-            largeCatItemId = 1L;
-            smallCatItemId = 1L;
-
-            smallCatMapper = mock(SmallCatMapper.class);
-            smallCatService = new SmallCatServiceImpl(smallCatMapper);
-        }
-
-        @DisplayName("소분류 항목 Preview 들을 조회할 수 있다.")
-        @Test
-        void getItemPreviewsTest(){
-            //given
-            SmallCatItemPreview preview = SmallCatItemPreview.builder()
-                    .id(10L)
-                    .build();
-            when(smallCatMapper.selectItemPreviews(checklistId, largeCatItemId)).thenReturn(List.of(preview));
-
-            //when
-            List<SmallCatItemPreviewResponse> result = smallCatService.findItemPreviews(checklistId, largeCatItemId);
-
-            //then
-            assertThat(result).isNotNull();
-            assertThat(result).hasSize(1);
-            assertThat(result).extracting(SmallCatItemPreviewResponse::getId)
-                    .containsExactly(10L);
-        }
-
 
         @DisplayName("소분류 항목 1개를 조회할 수 있다.")
         @Test
         void getSmallCatItemTest() {
-            //given
-            SmallCatItem item = SmallCatItem.builder()
-                    .id(10L)
-                    .build();
+            // given
+            SmallCatItem item = SmallCatItem.builder().id(10L).build();
             when(smallCatMapper.selectItem(checklistId, largeCatItemId, smallCatItemId)).thenReturn(item);
 
-            //when
+            // when
             var result = smallCatService.findItem(checklistId, largeCatItemId, smallCatItemId);
 
-            //then
+            // then
             assertThat(result).isNotNull();
             assertEquals(result.getId(), item.getId());
+        }
+
+        @DisplayName("소분류 항목 Preview 들을 조회할 수 있다.")
+        @Test
+        void getItemPreviewsTest() {
+            // given
+            SmallCatItemPreview preview = SmallCatItemPreview.builder().id(10L).build();
+            when(smallCatMapper.selectItemPreviews(checklistId, largeCatItemId)).thenReturn(List.of(preview));
+
+            // when
+            List<SmallCatItemPreviewResponse> result = smallCatService.findItemPreviews(checklistId, largeCatItemId);
+
+            // then
+            assertThat(result).isNotNull().hasSize(1);
+            assertThat(result).extracting(SmallCatItemPreviewResponse::getId).containsExactly(10L);
+        }
+    }
+
+    @DisplayName("추가 관련 테스트")
+    @Nested
+    class AddTests {
+
+        @DisplayName("소분류 항목 1개 추가 실패시 예외처리")
+        @Test
+        void addItem_Exception_Test() {
+            // given
+            when(smallCatMapper.insertItem(any(SmallCatItem.class))).thenReturn(0L);
+            SmallCatItemDto dto = SmallCatItemDto.builder().build();
+
+            // when & then
+            assertThatThrownBy(() -> smallCatService.addItem(dto))
+                    .isInstanceOf(SmallCategoryItemAddException.class);
         }
 
         @DisplayName("소분류 항목을 추가할 수 있다.")
         @Test
         void addItemTest() {
-            //given
-            Long expectedResult = 1L;
+            // given
             SmallCatItemDto dto = SmallCatItemDto.builder()
+                    .checklistId(checklistId)
+                    .largeCatItemId(largeCatItemId)
                     .id(10L)
                     .build();
-            when(smallCatMapper.insertItem(any(SmallCatItem.class))).thenReturn(expectedResult);
+            when(smallCatMapper.insertItem(any(SmallCatItem.class))).thenReturn(1L);
 
-            //when
+            // when
             Long result = smallCatService.addItem(dto);
 
-            //then
-            assertEquals(expectedResult , result);
+            // then
+            assertEquals(1L, result);
             verify(smallCatMapper).insertItem(any(SmallCatItem.class));
+        }
+    }
 
+    @DisplayName("수정 관련 테스트")
+    @Nested
+    class UpdateTests {
+
+        @DisplayName("소분류 항목 1개 수정 실패시 예외처리")
+        @Test
+        void editItem_Exception_Test() {
+            // given
+            when(smallCatMapper.selectItem(checklistId, largeCatItemId, smallCatItemId))
+                    .thenReturn(SmallCatItem.builder().build());
+            when(smallCatMapper.updateItem(any(SmallCatItem.class))).thenReturn(0);
+            SmallCatItemDto dto = SmallCatItemDto.builder()
+                    .checklistId(checklistId)
+                    .largeCatItemId(largeCatItemId)
+                    .id(smallCatItemId)
+                    .build();
+
+            // when & then
+            assertThatThrownBy(() -> smallCatService.editItem(dto))
+                    .isInstanceOf(SmallCategoryItemUpdateException.class);
         }
 
         @DisplayName("소분류 항목 1개가 존재할 경우, 변경할 수 있다.")
         @Test
         void editItemTest() {
-            //given
+            // given
             SmallCatItemDto dto = SmallCatItemDto.builder()
-                    .id(checklistId)
-                    .id(largeCatItemId)
+                    .checklistId(checklistId)
+                    .largeCatItemId(largeCatItemId)
                     .id(smallCatItemId)
                     .build();
-            boolean expectedResult = true;
-            when(smallCatMapper.selectItem(dto.getChecklistId(), dto.getLargeCatItemId(), dto.getId())).thenReturn(mock(SmallCatItem.class));
+            when(smallCatMapper.selectItem(checklistId, largeCatItemId, smallCatItemId)).thenReturn(mock(SmallCatItem.class));
             when(smallCatMapper.updateItem(any(SmallCatItem.class))).thenReturn(1);
 
-            //when
+            // when
             boolean result = smallCatService.editItem(dto);
 
-            //then
-            assertEquals(expectedResult , result);
+            // then
+            assertEquals(true, result);
             verify(smallCatMapper).updateItem(any(SmallCatItem.class));
+        }
+    }
+
+    @DisplayName("삭제 관련 테스트")
+    @Nested
+    class DeleteTests {
+
+        @DisplayName("소분류 항목 1개 삭제 실패시 예외처리")
+        @Test
+        void deleteItem_Exception_Test() {
+            // given
+            when(smallCatMapper.selectItem(checklistId, largeCatItemId, smallCatItemId))
+                    .thenReturn(SmallCatItem.builder().build());
+            when(smallCatMapper.deleteItem(largeCatItemId, smallCatItemId)).thenReturn(0);
+
+            // when & then
+            assertThatThrownBy(() -> smallCatService.deleteItem(checklistId, largeCatItemId, smallCatItemId))
+                    .isInstanceOf(SmallCategoryItemDeleteException.class);
         }
 
         @DisplayName("소분류 항목 1개가 존재할 경우, 삭제할 수 있다.")
         @Test
         void deleteItemTest() {
-            //given
-            boolean expectedResult = true;
+            // given
             when(smallCatMapper.selectItem(checklistId, largeCatItemId, smallCatItemId)).thenReturn(mock(SmallCatItem.class));
             when(smallCatMapper.deleteItem(largeCatItemId, smallCatItemId)).thenReturn(1);
 
-            //when
+            // when
             boolean result = smallCatService.deleteItem(checklistId, largeCatItemId, smallCatItemId);
 
-            //then
-            assertEquals(expectedResult , result);
+            // then
+            assertEquals(true, result);
             verify(smallCatMapper).deleteItem(largeCatItemId, smallCatItemId);
+        }
 
+        @DisplayName("소분류 항목 여러개 삭제 실패시 예외처리")
+        @Test
+        void deleteAll_Exception_Test() {
+            // given
+            when(smallCatMapper.selectItemPreviews(checklistId, largeCatItemId))
+                    .thenReturn(List.of(SmallCatItemPreview.builder().build()));
+            when(smallCatMapper.deleteAllItems(checklistId, largeCatItemId)).thenReturn(0);
+
+            // when & then
+            assertThatThrownBy(() -> smallCatService.deleteAll(checklistId, largeCatItemId))
+                    .isInstanceOf(SmallCategoryItemDeleteException.class);
         }
 
         @DisplayName("소분류 항목들이 존재할 경우, 전체 삭제할 수 있다.")
         @Test
         void deleteAllItemsTest() {
-            //given
-            boolean expectedResult = true;
-            SmallCatItemPreview preview = SmallCatItemPreview.builder()
-                    .id(10L)
-                    .build();
+            // given
+            SmallCatItemPreview preview = SmallCatItemPreview.builder().id(10L).build();
             when(smallCatMapper.selectItemPreviews(checklistId, largeCatItemId)).thenReturn(List.of(preview));
             when(smallCatMapper.deleteAllItems(checklistId, largeCatItemId)).thenReturn(1);
 
-            //when
+            // when
             boolean result = smallCatService.deleteAll(checklistId, largeCatItemId);
 
-            //then
-            assertEquals(expectedResult , result);
+            // then
+            assertEquals(true, result);
             verify(smallCatMapper).deleteAllItems(checklistId, largeCatItemId);
-
         }
 
-    }
-    static class FakeMapper implements SmallCatMapper {
-        @Override
-        public List<SmallCatItemPreview> selectItemPreviews(Long checklistId, Long largeCatItemId) {
-            return List.of();
-        }
+        @DisplayName("삭제대상 없을 시 true 반환")
+        @Test
+        void deleteAll_Return_True_If_Select_Empty_Test() {
+            // given
+            when(smallCatMapper.selectItemPreviews(checklistId, largeCatItemId)).thenReturn(List.of());
 
-        @Override
-        public SmallCatItem selectItem(Long checklistId, Long largeCatItemId, Long smallCatItemId) {
-            return null;
-        }
+            // when
+            boolean result = smallCatService.deleteAll(checklistId, largeCatItemId);
 
-        @Override
-        public Long insertItem(SmallCatItem smallCatItem) {
-            return 0L;
-        }
-
-        @Override
-        public int updateItem(SmallCatItem smallCatItem) {
-            return 0;
-        }
-
-        @Override
-        public int deleteItem(Long largeCatItemId, Long smallCatItemId) {
-            return 0;
-        }
-
-        @Override
-        public int deleteAllItems(Long checklistId, Long largeCatItemId) {
-            return 0;
+            // then
+            assertThat(result).isTrue();
         }
     }
 }

--- a/src/test/java/org/swyp/weddy/domain/checklist/service/SmallCatServiceTest.java
+++ b/src/test/java/org/swyp/weddy/domain/checklist/service/SmallCatServiceTest.java
@@ -12,6 +12,7 @@ import org.swyp.weddy.domain.checklist.exception.SmallCategoryItemDeleteExceptio
 import org.swyp.weddy.domain.checklist.exception.SmallCategoryItemNotExistsException;
 import org.swyp.weddy.domain.checklist.exception.SmallCategoryItemUpdateException;
 import org.swyp.weddy.domain.checklist.service.dto.SmallCatItemDto;
+import org.swyp.weddy.domain.checklist.service.dto.SmallCatItemMoveDto;
 import org.swyp.weddy.domain.checklist.web.response.SmallCatItemPreviewResponse;
 
 import java.util.List;
@@ -45,7 +46,7 @@ class SmallCatServiceTest {
 
         @DisplayName("소분류 항목 1개 조회 실패시 예외처리")
         @Test
-        void findItem_Exception_Test() {
+        void findItemFailsWhenNotExists() {
             // given
             when(smallCatMapper.selectItem(checklistId, largeCatItemId, smallCatItemId)).thenReturn(null);
 
@@ -56,7 +57,7 @@ class SmallCatServiceTest {
 
         @DisplayName("소분류 항목 1개를 조회할 수 있다.")
         @Test
-        void getSmallCatItemTest() {
+        void findItemSuccess() {
             // given
             SmallCatItem item = SmallCatItem.builder().id(10L).build();
             when(smallCatMapper.selectItem(checklistId, largeCatItemId, smallCatItemId)).thenReturn(item);
@@ -71,7 +72,7 @@ class SmallCatServiceTest {
 
         @DisplayName("소분류 항목 Preview 들을 조회할 수 있다.")
         @Test
-        void getItemPreviewsTest() {
+        void findItemPreviewsSuccess() {
             // given
             SmallCatItemPreview preview = SmallCatItemPreview.builder().id(10L).build();
             when(smallCatMapper.selectItemPreviews(checklistId, largeCatItemId)).thenReturn(List.of(preview));
@@ -91,7 +92,7 @@ class SmallCatServiceTest {
 
         @DisplayName("소분류 항목 1개 추가 실패시 예외처리")
         @Test
-        void addItem_Exception_Test() {
+        void addItemFailsWhenInsertFails() {
             // given
             when(smallCatMapper.insertItem(any(SmallCatItem.class))).thenReturn(0L);
             SmallCatItemDto dto = SmallCatItemDto.builder().build();
@@ -103,7 +104,7 @@ class SmallCatServiceTest {
 
         @DisplayName("소분류 항목을 추가할 수 있다.")
         @Test
-        void addItemTest() {
+        void addItemSuccess() {
             // given
             SmallCatItemDto dto = SmallCatItemDto.builder()
                     .checklistId(checklistId)
@@ -127,7 +128,7 @@ class SmallCatServiceTest {
 
         @DisplayName("소분류 항목 1개 수정 실패시 예외처리")
         @Test
-        void editItem_Exception_Test() {
+        void editItemFailsWhenUpdateFails() {
             // given
             when(smallCatMapper.selectItem(checklistId, largeCatItemId, smallCatItemId))
                     .thenReturn(SmallCatItem.builder().build());
@@ -145,7 +146,7 @@ class SmallCatServiceTest {
 
         @DisplayName("소분류 항목 1개가 존재할 경우, 변경할 수 있다.")
         @Test
-        void editItemTest() {
+        void editItemSuccess() {
             // given
             SmallCatItemDto dto = SmallCatItemDto.builder()
                     .checklistId(checklistId)
@@ -170,7 +171,7 @@ class SmallCatServiceTest {
 
         @DisplayName("소분류 항목 1개 삭제 실패시 예외처리")
         @Test
-        void deleteItem_Exception_Test() {
+        void deleteItemFailsWhenDeleteFails() {
             // given
             when(smallCatMapper.selectItem(checklistId, largeCatItemId, smallCatItemId))
                     .thenReturn(SmallCatItem.builder().build());
@@ -183,7 +184,7 @@ class SmallCatServiceTest {
 
         @DisplayName("소분류 항목 1개가 존재할 경우, 삭제할 수 있다.")
         @Test
-        void deleteItemTest() {
+        void deleteItemSuccess() {
             // given
             when(smallCatMapper.selectItem(checklistId, largeCatItemId, smallCatItemId)).thenReturn(mock(SmallCatItem.class));
             when(smallCatMapper.deleteItem(largeCatItemId, smallCatItemId)).thenReturn(1);
@@ -198,7 +199,7 @@ class SmallCatServiceTest {
 
         @DisplayName("소분류 항목 여러개 삭제 실패시 예외처리")
         @Test
-        void deleteAll_Exception_Test() {
+        void deleteAllFailsWhenDeleteFails() {
             // given
             when(smallCatMapper.selectItemPreviews(checklistId, largeCatItemId))
                     .thenReturn(List.of(SmallCatItemPreview.builder().build()));
@@ -211,7 +212,7 @@ class SmallCatServiceTest {
 
         @DisplayName("소분류 항목들이 존재할 경우, 전체 삭제할 수 있다.")
         @Test
-        void deleteAllItemsTest() {
+        void deleteAllSuccess() {
             // given
             SmallCatItemPreview preview = SmallCatItemPreview.builder().id(10L).build();
             when(smallCatMapper.selectItemPreviews(checklistId, largeCatItemId)).thenReturn(List.of(preview));
@@ -227,7 +228,7 @@ class SmallCatServiceTest {
 
         @DisplayName("삭제대상 없을 시 true 반환")
         @Test
-        void deleteAll_Return_True_If_Select_Empty_Test() {
+        void deleteAllSuccessWhenEmpty() {
             // given
             when(smallCatMapper.selectItemPreviews(checklistId, largeCatItemId)).thenReturn(List.of());
 
@@ -236,6 +237,43 @@ class SmallCatServiceTest {
 
             // then
             assertThat(result).isTrue();
+        }
+    }
+
+    @DisplayName("항목 이동 관련 테스트")
+    @Nested
+    class MoveTests {
+
+        @DisplayName("항목 이동 대상 없을 시 예외처리")
+        @Test
+        void moveItemFailsWhenNoTargets() {
+            // given
+            SmallCatItemMoveDto dto = mock(SmallCatItemMoveDto.class);
+            when(dto.getSmallCatItemIds()).thenReturn(List.of());
+
+            // when & then
+            assertThatThrownBy(() -> smallCatService.moveItem(dto))
+                    .isInstanceOf(SmallCategoryItemNotExistsException.class);
+        }
+
+        @DisplayName("이동 대상이 있을 시 이동 성공")
+        @Test
+        void moveItemSuccess() {
+            // given
+            SmallCatItemMoveDto dto = SmallCatItemMoveDto.builder()
+                    .checklistId(checklistId)
+                    .largeCatItemId(largeCatItemId)
+                    .smallCatItemIds(List.of(smallCatItemId))
+                    .build();
+            when(smallCatMapper.selectItems(checklistId, largeCatItemId)).thenReturn(List.of());
+            when(smallCatMapper.moveItem(any(SmallCatItem.class))).thenReturn(1);
+
+            // when
+            boolean result = smallCatService.moveItem(dto);
+
+            // then
+            assertThat(result).isTrue();
+            verify(smallCatMapper, times(1)).moveItem(any(SmallCatItem.class));
         }
     }
 }

--- a/src/test/java/org/swyp/weddy/domain/checklist/web/SmallCatControllerTest.java
+++ b/src/test/java/org/swyp/weddy/domain/checklist/web/SmallCatControllerTest.java
@@ -7,6 +7,8 @@ import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import org.swyp.weddy.domain.checklist.service.SmallCatService;
 import org.swyp.weddy.domain.checklist.service.dto.SmallCatItemDto;
+import org.swyp.weddy.domain.checklist.service.dto.SmallCatItemMoveDto;
+import org.swyp.weddy.domain.checklist.web.request.SmallCatItemMoveRequest;
 import org.swyp.weddy.domain.checklist.web.request.SmallCatItemPatchRequest;
 import org.swyp.weddy.domain.checklist.web.request.SmallCatItemPostRequest;
 import org.swyp.weddy.domain.checklist.web.response.SmallCatItemPreviewResponse;
@@ -175,5 +177,39 @@ class SmallCatControllerTest {
             assertEquals(true, result.getBody());
             verify(smallCatService).deleteAll(checklistId, largeCatItemId);
         }
+    }
+
+    @Nested
+    class MoveItemTest {
+        @DisplayName("소분류 항목 이동 성공 시 true 리턴.")
+        @Test
+        void testMoveItemReturnTrue() {
+            //given
+            SmallCatItemMoveRequest request = new SmallCatItemMoveRequest();
+            when(smallCatService.moveItem(any(SmallCatItemMoveDto.class))).thenReturn(true);
+
+            //when
+            var result = smallCatController.moveItem(request);
+
+            //then
+            assertEquals(200, result.getStatusCodeValue());
+            assertEquals(true, result.getBody());
+        }
+
+        @DisplayName("request 값이 Service객체로 올바르게 전달되는지 검증한다.")
+        @Test
+        void testMoveItemArgument() {
+            //given
+            SmallCatItemMoveRequest request = new SmallCatItemMoveRequest(checklistId, largeCatItemId, List.of(smallCatItemId));
+
+            //when
+            smallCatController.moveItem(request);
+
+            //then
+            ArgumentCaptor<SmallCatItemMoveDto> captor = ArgumentCaptor.forClass(SmallCatItemMoveDto.class);
+            verify(smallCatService).moveItem(captor.capture());
+            assertEquals(request.getSmallCatItemIds(), captor.getValue().getSmallCatItemIds());
+        }
+
     }
 }


### PR DESCRIPTION
- 소분류 항목 이동 기능 구현 했습니다.
- 테스트 코드도 추가했습니다.
- schema가 변경되어, small_cat_item 에 "sequence"컬럼이 추가되었습니다.
- 프론트에서 소분류 항목 addItem과 deleteItem시에 항목이 이동되는데, 이 부분을 프론트에서 추가 삭제 시 moveItem을 호출해야할지, 백에서 이를 처리해야할 지 결정이 필요합니다.
