### PR TITLE
대분류 항목 이동 기능 구현

### DIFF
--- a/src/main/java/org/swyp/weddy/common/exception/ControllerAdvice.java
+++ b/src/main/java/org/swyp/weddy/common/exception/ControllerAdvice.java
@@ -67,6 +67,13 @@ public class ControllerAdvice {
         return errorResponse.makeResponseEntity();
     }
 
+    @ExceptionHandler(LargeCatItemUpdateException.class)
+    protected ResponseEntity<ErrorResponse> LargeCatItemUpdateException(final LargeCatItemNotExistsException exception) {
+        ErrorResponse errorResponse = new ErrorResponse(exception.getErrorCode());
+        return errorResponse.makeResponseEntity();
+    }
+
+
     @ExceptionHandler(SmallCategoryItemNotExistsException.class)
     protected ResponseEntity<ErrorResponse> handleSmallCategoryItemNotExistsException(final SmallCategoryItemNotExistsException exception) {
         ErrorResponse errorResponse = new ErrorResponse(exception.getErrorCode());

--- a/src/main/java/org/swyp/weddy/common/exception/ErrorCode.java
+++ b/src/main/java/org/swyp/weddy/common/exception/ErrorCode.java
@@ -8,9 +8,9 @@ public enum ErrorCode {
     NOT_EXISTS         (404, "리소스가 존재하지 않음"),
     TOKEN_EXPIRED      (420, "JWT 토큰이 만료됨"),
     TOKEN_INVALID      (421, "JWT 리프레시 토큰이 유효하지 않음"),
-    DELETE_FAILED      (500, "소분류 항목 삭제에 실패하였습니다"),
-    UPDATE_FAILED      (500, "소분류 항목 변경에 실패하였습니다"),
-    ADD_FAILED         (500, "소분류 항목 추가에 실패하였습니다"),
+    DELETE_FAILED      (500, "항목 삭제에 실패하였습니다"),
+    UPDATE_FAILED      (500, "항목 변경에 실패하였습니다"),
+    ADD_FAILED         (500, "항목 추가에 실패하였습니다"),
 
             ;
 

--- a/src/main/java/org/swyp/weddy/domain/checklist/dao/LargeCatMapper.java
+++ b/src/main/java/org/swyp/weddy/domain/checklist/dao/LargeCatMapper.java
@@ -17,4 +17,6 @@ public interface LargeCatMapper {
     Long updateItem(LargeCatItem item);
 
     Long deleteItem(LargeCatItem item);
+
+    int updateItemSequence(LargeCatItem item);
 }

--- a/src/main/java/org/swyp/weddy/domain/checklist/entity/LargeCatItem.java
+++ b/src/main/java/org/swyp/weddy/domain/checklist/entity/LargeCatItem.java
@@ -3,13 +3,18 @@ package org.swyp.weddy.domain.checklist.entity;
 import org.swyp.weddy.domain.checklist.service.dto.LargeCatItemAssignDto;
 import org.swyp.weddy.domain.checklist.service.dto.LargeCatItemDeleteDto;
 import org.swyp.weddy.domain.checklist.service.dto.LargeCatItemEditDto;
+import org.swyp.weddy.domain.checklist.service.dto.LargeCatItemMoveDto;
 
 import java.sql.Timestamp;
+import java.util.ArrayList;
+import java.util.List;
 
 public class LargeCatItem {
     private Long id;
     private Long checklistId;
     private String title;
+
+    private Long sequence;
     private Timestamp createdAt;
     private Timestamp updatedAt;
     private Boolean isDeleted;
@@ -33,6 +38,13 @@ public class LargeCatItem {
         this.createdAt = createdAt;
         this.updatedAt = updatedAt;
         this.isDeleted = isDeleted;
+    }
+
+    public LargeCatItem(Long id, Long checklistId, Long sequence, Timestamp updatedAt) {
+        this.id = id;
+        this.checklistId = checklistId;
+        this.sequence = sequence;
+        this.updatedAt = updatedAt;
     }
 
     public static LargeCatItem from(LargeCatItemAssignDto dto) {
@@ -65,6 +77,23 @@ public class LargeCatItem {
                 new Timestamp(System.currentTimeMillis()),
                 Boolean.TRUE
         );
+    }
+
+
+    public static List<LargeCatItem> ofMove(LargeCatItemMoveDto dto) {
+        List<Long> idSequence = dto.getIdSequence();
+        ArrayList<LargeCatItem> itemsAfterMove = new ArrayList<>(idSequence.size());
+
+        for (int i = 0; i < idSequence.size(); i++) {
+            itemsAfterMove.add(new LargeCatItem(
+                    idSequence.get(i),
+                    dto.getChecklistId(),
+                    (long) i,
+                    new Timestamp(System.currentTimeMillis())
+            ));
+        }
+
+        return itemsAfterMove;
     }
 
     public Long getId() {

--- a/src/main/java/org/swyp/weddy/domain/checklist/exception/LargeCatItemUpdateException.java
+++ b/src/main/java/org/swyp/weddy/domain/checklist/exception/LargeCatItemUpdateException.java
@@ -1,0 +1,17 @@
+package org.swyp.weddy.domain.checklist.exception;
+
+import org.swyp.weddy.common.exception.ErrorCode;
+
+public class LargeCatItemUpdateException extends RuntimeException {
+
+    private final ErrorCode errorCode;
+
+    public LargeCatItemUpdateException(ErrorCode errorCode) {
+        super(errorCode.getReason());
+        this.errorCode = errorCode;
+    }
+
+    public ErrorCode getErrorCode() {
+        return this.errorCode;
+    }
+}

--- a/src/main/java/org/swyp/weddy/domain/checklist/service/LargeCatService.java
+++ b/src/main/java/org/swyp/weddy/domain/checklist/service/LargeCatService.java
@@ -3,6 +3,7 @@ package org.swyp.weddy.domain.checklist.service;
 import org.swyp.weddy.domain.checklist.service.dto.LargeCatItemAssignDto;
 import org.swyp.weddy.domain.checklist.service.dto.LargeCatItemDeleteDto;
 import org.swyp.weddy.domain.checklist.service.dto.LargeCatItemEditDto;
+import org.swyp.weddy.domain.checklist.service.dto.LargeCatItemMoveDto;
 import org.swyp.weddy.domain.checklist.web.response.LargeCatItemResponse;
 
 import java.util.List;
@@ -21,4 +22,6 @@ public interface LargeCatService {
     Long deleteItemWithSmallItems(LargeCatItemDeleteDto dto);
 
     List<LargeCatItemResponse> findAllItems(Long checklistId);
+
+    void moveItem(LargeCatItemMoveDto dto);
 }

--- a/src/main/java/org/swyp/weddy/domain/checklist/service/LargeCatServiceImpl.java
+++ b/src/main/java/org/swyp/weddy/domain/checklist/service/LargeCatServiceImpl.java
@@ -6,6 +6,7 @@ import org.swyp.weddy.common.exception.ErrorCode;
 import org.swyp.weddy.domain.checklist.dao.LargeCatMapper;
 import org.swyp.weddy.domain.checklist.entity.LargeCatItem;
 import org.swyp.weddy.domain.checklist.exception.LargeCatItemNotExistsException;
+import org.swyp.weddy.domain.checklist.exception.LargeCatItemUpdateException;
 import org.swyp.weddy.domain.checklist.service.dto.LargeCatItemAssignDto;
 import org.swyp.weddy.domain.checklist.service.dto.LargeCatItemDeleteDto;
 import org.swyp.weddy.domain.checklist.service.dto.LargeCatItemEditDto;
@@ -133,14 +134,14 @@ public class LargeCatServiceImpl implements LargeCatService {
     public void moveItem(LargeCatItemMoveDto dto) {
 
         if (dto.getIdSequence() == null || dto.getIdSequence().isEmpty()) {
-            //예외처리
+            throw new LargeCatItemNotExistsException(ErrorCode.NOT_EXISTS);
         }
 
         List<LargeCatItem> itemsAfterMove = LargeCatItem.ofMove(dto);
         for (LargeCatItem item : itemsAfterMove) {
             int updatedRow = mapper.updateItemSequence(item);
             if (updatedRow != 1) {
-                //예외처리
+                throw new LargeCatItemUpdateException(ErrorCode.UPDATE_FAILED);
             }
         }
     }

--- a/src/main/java/org/swyp/weddy/domain/checklist/service/LargeCatServiceImpl.java
+++ b/src/main/java/org/swyp/weddy/domain/checklist/service/LargeCatServiceImpl.java
@@ -9,6 +9,7 @@ import org.swyp.weddy.domain.checklist.exception.LargeCatItemNotExistsException;
 import org.swyp.weddy.domain.checklist.service.dto.LargeCatItemAssignDto;
 import org.swyp.weddy.domain.checklist.service.dto.LargeCatItemDeleteDto;
 import org.swyp.weddy.domain.checklist.service.dto.LargeCatItemEditDto;
+import org.swyp.weddy.domain.checklist.service.dto.LargeCatItemMoveDto;
 import org.swyp.weddy.domain.checklist.web.response.LargeCatItemResponse;
 import org.swyp.weddy.domain.checklist.web.response.SmallCatItemPreviewResponse;
 
@@ -126,5 +127,21 @@ public class LargeCatServiceImpl implements LargeCatService {
         }
 
         return result;
+    }
+
+    @Override
+    public void moveItem(LargeCatItemMoveDto dto) {
+
+        if (dto.getIdSequence() == null || dto.getIdSequence().isEmpty()) {
+            //예외처리
+        }
+
+        List<LargeCatItem> itemsAfterMove = LargeCatItem.ofMove(dto);
+        for (LargeCatItem item : itemsAfterMove) {
+            int updatedRow = mapper.updateItemSequence(item);
+            if (updatedRow != 1) {
+                //예외처리
+            }
+        }
     }
 }

--- a/src/main/java/org/swyp/weddy/domain/checklist/service/dto/LargeCatItemMoveDto.java
+++ b/src/main/java/org/swyp/weddy/domain/checklist/service/dto/LargeCatItemMoveDto.java
@@ -1,0 +1,31 @@
+package org.swyp.weddy.domain.checklist.service.dto;
+
+import org.swyp.weddy.domain.checklist.web.request.LargeCatItemMoveRequest;
+
+import java.util.List;
+
+public class LargeCatItemMoveDto {
+    private Long checklistId;
+    private List<Long> idSequence;
+
+    public LargeCatItemMoveDto(Long checklistId, List<Long> idSequence) {
+        this.checklistId = checklistId;
+        this.idSequence = idSequence;
+    }
+
+    public static LargeCatItemMoveDto of(Long checklistId, LargeCatItemMoveRequest request) {
+        return new LargeCatItemMoveDto(
+                checklistId,
+                request.getIdSequence()
+        );
+    }
+
+    public Long getChecklistId() {
+        return checklistId;
+    }
+
+    public List<Long> getIdSequence() {
+        return idSequence;
+    }
+
+}

--- a/src/main/java/org/swyp/weddy/domain/checklist/web/LargeCatController.java
+++ b/src/main/java/org/swyp/weddy/domain/checklist/web/LargeCatController.java
@@ -5,12 +5,10 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import org.swyp.weddy.domain.checklist.service.ChecklistService;
 import org.swyp.weddy.domain.checklist.service.LargeCatService;
-import org.swyp.weddy.domain.checklist.service.dto.ChecklistDto;
-import org.swyp.weddy.domain.checklist.service.dto.LargeCatItemAssignDto;
-import org.swyp.weddy.domain.checklist.service.dto.LargeCatItemDeleteDto;
-import org.swyp.weddy.domain.checklist.service.dto.LargeCatItemEditDto;
+import org.swyp.weddy.domain.checklist.service.dto.*;
 import org.swyp.weddy.domain.checklist.web.request.LargeCatItemDeleteRequest;
 import org.swyp.weddy.domain.checklist.web.request.LargeCatItemEditRequest;
+import org.swyp.weddy.domain.checklist.web.request.LargeCatItemMoveRequest;
 import org.swyp.weddy.domain.checklist.web.request.LargeCatItemPostRequest;
 import org.swyp.weddy.domain.checklist.web.response.ChecklistResponse;
 import org.swyp.weddy.domain.checklist.web.response.LargeCatItemResponse;
@@ -89,6 +87,19 @@ public class LargeCatController {
 
         LargeCatItemDeleteDto deleteDto = LargeCatItemDeleteDto.of(checklist.getId(), request);
         largeCatService.deleteItemWithSmallItems(deleteDto);
+
+        return ResponseEntity.ok().build();
+    }
+
+    @PatchMapping("/move")
+    public ResponseEntity<Void> moveItem(@RequestBody LargeCatItemMoveRequest request) {
+        String memberId = request.getMemberId();
+        ChecklistDto dto = ChecklistDto.from(memberId);
+
+        ChecklistResponse checklist = checklistService.findChecklist(dto);
+
+        LargeCatItemMoveDto moveDto = LargeCatItemMoveDto.of(checklist.getId(), request);
+        largeCatService.moveItem(moveDto);
 
         return ResponseEntity.ok().build();
     }

--- a/src/main/java/org/swyp/weddy/domain/checklist/web/request/LargeCatItemMoveRequest.java
+++ b/src/main/java/org/swyp/weddy/domain/checklist/web/request/LargeCatItemMoveRequest.java
@@ -1,0 +1,25 @@
+package org.swyp.weddy.domain.checklist.web.request;
+
+import java.util.List;
+
+public class LargeCatItemMoveRequest {
+    private String memberId;
+    private List<Long> idSequence;
+
+    public LargeCatItemMoveRequest() {
+    }
+
+    public LargeCatItemMoveRequest(String memberId, List<Long> idSequnce) {
+        this.memberId = memberId;
+        this.idSequence = idSequnce;
+    }
+
+    public String getMemberId() {
+        return memberId;
+    }
+
+    public List<Long> getIdSequence() {
+        return idSequence;
+    }
+
+}

--- a/src/main/resources/mapper/LargeCatMapper.xml
+++ b/src/main/resources/mapper/LargeCatMapper.xml
@@ -26,6 +26,7 @@
         FROM large_category_item
         WHERE checklist_id = #{checklistId}
           AND is_deleted = false
+     ORDER BY sequence ASC
     </select>
 
     <insert id="insertItem" useGeneratedKeys="true" keyProperty="id"
@@ -58,5 +59,14 @@
             updated_at = #{updatedAt}
         WHERE id = #{id}
           AND checklist_id = #{checklistId}
+    </update>
+
+    <update id="updateItemSequence" useGeneratedKeys="true" keyProperty="id"
+            parameterType="org.swyp.weddy.domain.checklist.entity.LargeCatItem">
+        UPDATE large_category_item
+           SET sequence      = #{sequence},
+               updated_at    = #{updatedAt}
+         WHERE checklist_id  = #{checklistId}
+           AND id            = #{id}
     </update>
 </mapper>

--- a/src/main/resources/sql/schema.sql
+++ b/src/main/resources/sql/schema.sql
@@ -33,6 +33,7 @@ CREATE TABLE `large_category_item`
     `id`           bigint PRIMARY KEY NOT NULL AUTO_INCREMENT,
     `checklist_id` bigint             NOT NULL,
     `title`        varchar(255),
+    `sequence`     bigint,
     `created_at`   timestamp,
     `updated_at`   timestamp,
     `is_deleted`   bool

--- a/src/test/java/org/swyp/weddy/domain/checklist/service/LargeCatServiceTest.java
+++ b/src/test/java/org/swyp/weddy/domain/checklist/service/LargeCatServiceTest.java
@@ -13,6 +13,7 @@ import org.swyp.weddy.domain.checklist.web.response.SmallCatItemPreviewResponse;
 import org.swyp.weddy.domain.checklist.web.response.SmallCatItemResponse;
 
 import java.sql.Timestamp;
+import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
 
@@ -150,6 +151,17 @@ class LargeCatServiceTest {
         }
     }
 
+    @DisplayName("moveItem()")
+    @Nested
+    class MoveItem {
+        @DisplayName("대분류 항목을 이동할 수 있다.")
+        @Test
+        public void move_large_cat_item() {
+            LargeCatServiceImpl largeCatService = new LargeCatServiceImpl(new FakeLargeCatMapper(), new FakeSmallCatService());
+            largeCatService.moveItem(new LargeCatItemMoveDto(1L, new ArrayList<Long>(List.of())));
+        }
+    }
+
     private static class FakeSmallCatService implements SmallCatService {
         @Override
         public List<SmallCatItemPreviewResponse> findItemPreviews(Long checklistId, Long largeCatItemId) {
@@ -241,5 +253,11 @@ class LargeCatServiceTest {
         public Long deleteItem(LargeCatItem item) {
             return 0L;
         }
+
+        @Override
+        public int updateItemSequence(LargeCatItem item) {
+            return 1;
+        }
+
     }
 }

--- a/src/test/java/org/swyp/weddy/domain/checklist/web/LargeCatControllerTest.java
+++ b/src/test/java/org/swyp/weddy/domain/checklist/web/LargeCatControllerTest.java
@@ -9,6 +9,7 @@ import org.swyp.weddy.domain.checklist.service.LargeCatService;
 import org.swyp.weddy.domain.checklist.service.dto.*;
 import org.swyp.weddy.domain.checklist.web.request.LargeCatItemDeleteRequest;
 import org.swyp.weddy.domain.checklist.web.request.LargeCatItemEditRequest;
+import org.swyp.weddy.domain.checklist.web.request.LargeCatItemMoveRequest;
 import org.swyp.weddy.domain.checklist.web.request.LargeCatItemPostRequest;
 import org.swyp.weddy.domain.checklist.web.response.ChecklistResponse;
 import org.swyp.weddy.domain.checklist.web.response.LargeCatItemResponse;
@@ -157,6 +158,40 @@ class LargeCatControllerTest {
             LargeCatItemDeleteRequest request = new LargeCatItemDeleteRequest(memberId, itemId);
 
             assertThat(controller.deleteItem(request)).isEqualTo(ResponseEntity.ok().build());
+        }
+    }
+
+    @DisplayName("moveItem()")
+    @Nested
+    class MoveItemTest {
+        @DisplayName("대분류 항목 이동 요청을 받을 수 있다")
+        @Test
+        public void receive_move_large_item_message() {
+            LargeCatController controller = new LargeCatController(
+                    new FakeLargeCatService(),
+                    new FakeChecklistService()
+            );
+            String memberId = "1";
+            List<Long> idSequence = List.of();
+
+            LargeCatItemMoveRequest request = new LargeCatItemMoveRequest(memberId, idSequence);
+
+            controller.moveItem(request);
+        }
+
+        @DisplayName("대분류 항목 이동 결과를 반환할 수 있다")
+        @Test
+        public void returns_move_large_item() {
+            LargeCatController controller = new LargeCatController(
+                    new FakeLargeCatService(),
+                    new FakeChecklistService()
+            );
+            String memberId = "1";
+            List<Long> idSequence = List.of();
+
+            LargeCatItemMoveRequest request = new LargeCatItemMoveRequest(memberId, idSequence);
+
+            assertThat(controller.moveItem(request)).isEqualTo(ResponseEntity.ok().build());
         }
     }
 

--- a/src/test/java/org/swyp/weddy/domain/checklist/web/LargeCatControllerTest.java
+++ b/src/test/java/org/swyp/weddy/domain/checklist/web/LargeCatControllerTest.java
@@ -6,10 +6,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.http.ResponseEntity;
 import org.swyp.weddy.domain.checklist.service.ChecklistService;
 import org.swyp.weddy.domain.checklist.service.LargeCatService;
-import org.swyp.weddy.domain.checklist.service.dto.ChecklistDto;
-import org.swyp.weddy.domain.checklist.service.dto.LargeCatItemAssignDto;
-import org.swyp.weddy.domain.checklist.service.dto.LargeCatItemDeleteDto;
-import org.swyp.weddy.domain.checklist.service.dto.LargeCatItemEditDto;
+import org.swyp.weddy.domain.checklist.service.dto.*;
 import org.swyp.weddy.domain.checklist.web.request.LargeCatItemDeleteRequest;
 import org.swyp.weddy.domain.checklist.web.request.LargeCatItemEditRequest;
 import org.swyp.weddy.domain.checklist.web.request.LargeCatItemPostRequest;
@@ -206,6 +203,10 @@ class LargeCatControllerTest {
                     new LargeCatItemResponse(1L, 1L, "test"),
                     new LargeCatItemResponse(1L, 1L, "test")
             );
+        }
+
+        @Override
+        public void moveItem(LargeCatItemMoveDto dto) {
         }
     }
 


### PR DESCRIPTION
대분류 항목 이동 기능 구현하였습니다.
- 요청받는 값과, 예외처리 모두 기존의 large-cat-item 형식을 따르고자 했습니다.
- 운영서버DB large-category-item 테이블에 sequence컬럼 추가 했습니다.
- 현재 위 코드로 운영 서버에 배포하여 프론트 쪽에서 테스트 진행할 수 있도록 했습니다.
- 기능 구현은 소분류 항목 이동과 같은 매커니즘으로 구현했습니다.


