### PR TITLE
AWS S3를 이용하여 파일(이미지)업로드 기능

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -37,6 +37,9 @@ dependencies {
 
 	implementation 'org.slf4j:slf4j-api:2.0.13'
 
+	implementation 'software.amazon.awssdk:s3:2.30.26'
+
+
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'org.mybatis.spring.boot:mybatis-spring-boot-starter-test:3.0.4'
 

--- a/src/main/java/org/swyp/weddy/common/config/StorageConfig.java
+++ b/src/main/java/org/swyp/weddy/common/config/StorageConfig.java
@@ -1,0 +1,44 @@
+package org.swyp.weddy.common.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.presigner.S3Presigner;
+
+@Configuration
+public class StorageConfig {
+
+    private final String accessKey;
+    private final String secretKey;
+    private final String region;
+
+    public StorageConfig(@Value("${aws.access-key-id}") String accessKey,
+                         @Value("${aws.secret-access-key}") String secretKey,
+                         @Value("${aws.region}") String region) {
+        this.accessKey = accessKey;
+        this.secretKey = secretKey;
+        this.region = region;
+    }
+
+    @Bean
+    public S3Client s3Client() {
+        AwsBasicCredentials credentials = AwsBasicCredentials.create(accessKey, secretKey);
+        return S3Client.builder()
+                .region(Region.of(region))
+                .credentialsProvider(StaticCredentialsProvider.create(credentials))
+                .build();
+    }
+
+    @Bean
+    public S3Presigner s3Presigner() {
+        AwsBasicCredentials credentials = AwsBasicCredentials.create(accessKey, secretKey);
+        return S3Presigner.builder()
+                .region(Region.of(region))
+                .credentialsProvider(StaticCredentialsProvider.create(credentials))
+                .build();
+    }
+}

--- a/src/main/java/org/swyp/weddy/common/exception/ControllerAdvice.java
+++ b/src/main/java/org/swyp/weddy/common/exception/ControllerAdvice.java
@@ -8,6 +8,8 @@ import org.swyp.weddy.domain.auth.exception.JwtTokenExpiredException;
 import org.swyp.weddy.domain.auth.exception.JwtUnauthorizedException;
 import org.swyp.weddy.domain.auth.exception.UserNotFoundException;
 import org.swyp.weddy.domain.checklist.exception.*;
+import org.swyp.weddy.domain.storage.exception.FileDeleteException;
+import org.swyp.weddy.domain.storage.exception.FileUploadException;
 import org.swyp.weddy.domain.wiki.exception.WikiNotFoundException;
 
 @RestControllerAdvice
@@ -94,6 +96,18 @@ public class ControllerAdvice {
 
     @ExceptionHandler(SmallCategoryItemDeleteException.class)
     protected ResponseEntity<ErrorResponse> SmallCategoryItemDeleteException(final SmallCategoryItemDeleteException exception) {
+        ErrorResponse errorResponse = new ErrorResponse(exception.getErrorCode());
+        return errorResponse.makeResponseEntity();
+    }
+
+    @ExceptionHandler(FileUploadException.class)
+    protected ResponseEntity<ErrorResponse> FileUploadException(final FileUploadException exception) {
+        ErrorResponse errorResponse = new ErrorResponse(exception.getErrorCode());
+        return errorResponse.makeResponseEntity();
+    }
+
+    @ExceptionHandler(FileDeleteException.class)
+    protected ResponseEntity<ErrorResponse> FileDeleteException(final FileDeleteException exception) {
         ErrorResponse errorResponse = new ErrorResponse(exception.getErrorCode());
         return errorResponse.makeResponseEntity();
     }

--- a/src/main/java/org/swyp/weddy/common/exception/ErrorCode.java
+++ b/src/main/java/org/swyp/weddy/common/exception/ErrorCode.java
@@ -12,6 +12,9 @@ public enum ErrorCode {
     UPDATE_FAILED      (500, "항목 변경에 실패하였습니다"),
     ADD_FAILED         (500, "항목 추가에 실패하였습니다"),
 
+    UPLOAD_FILE_FAILED (500, "파일 업로드에 실패하였습니다"),
+    DELETE_FILE_FAILED (500, "파일 삭제에 실패하였습니다"),
+
             ;
 
     private final Integer code;

--- a/src/main/java/org/swyp/weddy/domain/storage/exception/FileDeleteException.java
+++ b/src/main/java/org/swyp/weddy/domain/storage/exception/FileDeleteException.java
@@ -1,0 +1,17 @@
+package org.swyp.weddy.domain.storage.exception;
+
+import org.swyp.weddy.common.exception.ErrorCode;
+
+public class FileDeleteException extends RuntimeException{
+
+    private final ErrorCode errorCode;
+
+    public FileDeleteException(ErrorCode errorCode) {
+        super(errorCode.getReason());
+        this.errorCode = errorCode;
+    }
+
+    public ErrorCode getErrorCode() {
+        return this.errorCode;
+    }
+}

--- a/src/main/java/org/swyp/weddy/domain/storage/exception/FileUploadException.java
+++ b/src/main/java/org/swyp/weddy/domain/storage/exception/FileUploadException.java
@@ -1,0 +1,17 @@
+package org.swyp.weddy.domain.storage.exception;
+
+import org.swyp.weddy.common.exception.ErrorCode;
+
+public class FileUploadException extends RuntimeException{
+
+    private final ErrorCode errorCode;
+
+    public FileUploadException(ErrorCode errorCode) {
+        super(errorCode.getReason());
+        this.errorCode = errorCode;
+    }
+
+    public ErrorCode getErrorCode() {
+        return this.errorCode;
+    }
+}

--- a/src/main/java/org/swyp/weddy/domain/storage/service/FileStorageService.java
+++ b/src/main/java/org/swyp/weddy/domain/storage/service/FileStorageService.java
@@ -1,0 +1,74 @@
+package org.swyp.weddy.domain.storage.service;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+import software.amazon.awssdk.core.sync.RequestBody;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.DeleteObjectRequest;
+import software.amazon.awssdk.services.s3.model.GetObjectRequest;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+import software.amazon.awssdk.services.s3.presigner.S3Presigner;
+import software.amazon.awssdk.services.s3.presigner.model.GetObjectPresignRequest;
+import software.amazon.awssdk.services.s3.presigner.model.PresignedGetObjectRequest;
+
+import java.io.IOException;
+import java.net.URI;
+import java.time.Duration;
+
+@Slf4j
+@Service
+public class FileStorageService {
+    private final S3Client s3Client;
+    private final S3Presigner s3Presigner;
+    private final String bucketName;
+
+    public FileStorageService(S3Client s3Client, S3Presigner s3Presigner, @Value("${aws.s3.bucket}") String bucketName) {
+        this.s3Client = s3Client;
+        this.s3Presigner = s3Presigner;
+        this.bucketName = bucketName;
+    }
+
+    public String uploadFile(MultipartFile file) throws IOException {
+        String fileKey = System.currentTimeMillis() + "_" + file.getOriginalFilename();
+        PutObjectRequest putObjectRequest = PutObjectRequest.builder()
+                .bucket(bucketName)
+                .key(fileKey)
+                .build();
+        s3Client.putObject(putObjectRequest, RequestBody.fromInputStream(file.getInputStream(), file.getSize()));
+        return generatePresignedUrl(fileKey);
+    }
+
+    public void deleteFile(String fileUrl) {
+        String fileKey = extractFileKey(fileUrl);
+        DeleteObjectRequest deleteObjectRequest = DeleteObjectRequest.builder()
+                .bucket(bucketName)
+                .key(fileKey)
+                .build();
+        s3Client.deleteObject(deleteObjectRequest);
+    }
+
+    private String generatePresignedUrl(String fileKey) {
+        GetObjectRequest getObjectRequest = GetObjectRequest.builder()
+                .bucket(bucketName)
+                .key(fileKey)
+                .build();
+        PresignedGetObjectRequest presignedRequest = s3Presigner.presignGetObject(
+                GetObjectPresignRequest.builder()
+                        .signatureDuration(Duration.ofDays(7))
+                        .getObjectRequest(getObjectRequest)
+                        .build()
+        );
+        return presignedRequest.url().toString();
+    }
+    private String extractFileKey(String fileUrl) {
+        try {
+            URI uri = new URI(fileUrl);
+            String path = uri.getPath();
+            return path.substring( 1);
+        } catch (Exception e) {
+            throw new IllegalArgumentException("Invalid file identifier provided: " + fileUrl);
+        }
+    }
+}

--- a/src/main/java/org/swyp/weddy/domain/storage/web/FileController.java
+++ b/src/main/java/org/swyp/weddy/domain/storage/web/FileController.java
@@ -1,15 +1,9 @@
 package org.swyp.weddy.domain.storage.web;
 
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.DeleteMapping;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 import org.swyp.weddy.domain.storage.service.FileStorageService;
-
-import java.io.IOException;
 
 @RestController
 @RequestMapping("/api/files")
@@ -22,21 +16,13 @@ public class FileController {
 
     @PostMapping
     public ResponseEntity<String> uploadFile(@RequestParam("file") MultipartFile file) {
-        try {
             String fileUrl = storageService.uploadFile(file);
             return ResponseEntity.ok(fileUrl);
-        } catch (IOException e) {
-            return ResponseEntity.status(500).body("File upload failed: " + e.getMessage());
-        }
     }
 
     @DeleteMapping
     public ResponseEntity<String> deleteFile(@RequestParam("fileUrl") String fileUrl) {
-        try {
             storageService.deleteFile(fileUrl);
             return ResponseEntity.ok().build();
-        } catch (Exception e) {
-            return ResponseEntity.status(500).body("File deletion failed: " + e.getMessage());
-        }
     }
 }

--- a/src/main/java/org/swyp/weddy/domain/storage/web/FileController.java
+++ b/src/main/java/org/swyp/weddy/domain/storage/web/FileController.java
@@ -1,0 +1,42 @@
+package org.swyp.weddy.domain.storage.web;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
+import org.swyp.weddy.domain.storage.service.FileStorageService;
+
+import java.io.IOException;
+
+@RestController
+@RequestMapping("/api/files")
+public class FileController {
+    private final FileStorageService storageService;
+
+    public FileController(FileStorageService storageService) {
+        this.storageService = storageService;
+    }
+
+    @PostMapping
+    public ResponseEntity<String> uploadFile(@RequestParam("file") MultipartFile file) {
+        try {
+            String fileUrl = storageService.uploadFile(file);
+            return ResponseEntity.ok(fileUrl);
+        } catch (IOException e) {
+            return ResponseEntity.status(500).body("File upload failed: " + e.getMessage());
+        }
+    }
+
+    @DeleteMapping
+    public ResponseEntity<String> deleteFile(@RequestParam("fileUrl") String fileUrl) {
+        try {
+            storageService.deleteFile(fileUrl);
+            return ResponseEntity.ok().build();
+        } catch (Exception e) {
+            return ResponseEntity.status(500).body("File deletion failed: " + e.getMessage());
+        }
+    }
+}

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -9,6 +9,10 @@ spring:
     username: ${MYSQL_USERNAME}
     password: ${MYSQL_PASSWORD}
     driver-class-name: com.mysql.cj.jdbc.Driver
+  servlet:
+    multipart:
+      max-file-size: 10MB
+      max-request-size: 50MB
 
 mybatis:
   mapper-locations: classpath:mapper/*Mapper.xml

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -47,3 +47,10 @@ logging:
     com.mysql.cj.jdbc: DEBUG   # MySQL JDBC 로그
   pattern:
     console: "%clr(%d{yyyy-MM-dd HH:mm:ss}){faint} %clr(%-5level) %clr([%15.15t]){faint} %clr(%-40.40logger{39}){cyan} %clr(:){faint} %msg%n"
+
+aws:
+  access-key-id: ${AWS_ACCESS_KEY_ID}
+  secret-access-key: ${AWS_ACCESS_KEY_SECRET}
+  region: ap-northeast-2
+  s3:
+    bucket: weddy-bucket-2025

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -16,6 +16,10 @@ spring:
       mode: embedded
       schema-locations: classpath:sql/schema.sql
       data-locations: classpath:sql/data.sql
+  servlet:
+    multipart:
+      max-file-size: 10MB
+      max-request-size: 50MB
 
 mybatis:
   mapper-locations: classpath:mapper/*Mapper.xml
@@ -54,3 +58,10 @@ logging:
     org.h2.server: DEBUG       # H2 데이터베이스 로그
   pattern:
     console: "%clr(%d{yyyy-MM-dd HH:mm:ss}){faint} %clr(%-5level) %clr([%15.15t]){faint} %clr(%-40.40logger{39}){cyan} %clr(:){faint} %msg%n"
+
+aws:
+  access-key-id: ${AWS_ACCESS_KEY_ID}
+  secret-access-key: ${AWS_ACCESS_KEY_SECRET}
+  region: ap-northeast-2
+  s3:
+    bucket: weddy-bucket-2025

--- a/src/test/java/org/swyp/weddy/domain/storage/service/FileStorageServiceTest.java
+++ b/src/test/java/org/swyp/weddy/domain/storage/service/FileStorageServiceTest.java
@@ -39,6 +39,7 @@ class FileStorageServiceTest {
     }
 
     @Nested
+    @DisplayName("파일 업로드 테스트")
     class UploadTests {
         @DisplayName("파일 업로드 후 파일주소를 응답할 수 있다.")
         @Test
@@ -62,7 +63,7 @@ class FileStorageServiceTest {
 
         }
 
-        @DisplayName("S3 업로드 실패 시 예외처리가 발생한다.")
+        @DisplayName("업로드 실패 시 예외처리가 발생한다.")
         @Test
         void throws_exception_if_s3_upload_failed() {
             // given
@@ -94,7 +95,7 @@ class FileStorageServiceTest {
             verify(s3Client, times(1)).deleteObject(any(DeleteObjectRequest.class));
         }
 
-        @DisplayName("S3 삭제 실패 시 FileDeleteException을 던진다")
+        @DisplayName("파일 삭제 실패 시 예외처리가 발생한다")
         @Test
         void throws_exception_if_s3_delete_failed() {
             // given

--- a/src/test/java/org/swyp/weddy/domain/storage/service/FileStorageServiceTest.java
+++ b/src/test/java/org/swyp/weddy/domain/storage/service/FileStorageServiceTest.java
@@ -1,0 +1,111 @@
+package org.swyp.weddy.domain.storage.service;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.web.multipart.MultipartFile;
+import org.swyp.weddy.domain.storage.exception.FileDeleteException;
+import software.amazon.awssdk.core.sync.RequestBody;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.DeleteObjectRequest;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+import software.amazon.awssdk.services.s3.model.PutObjectResponse;
+import software.amazon.awssdk.services.s3.presigner.S3Presigner;
+import software.amazon.awssdk.services.s3.presigner.model.GetObjectPresignRequest;
+import software.amazon.awssdk.services.s3.presigner.model.PresignedGetObjectRequest;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URI;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+class FileStorageServiceTest {
+    S3Client s3Client;
+    S3Presigner s3Presigner;
+    String bucketName;
+    FileStorageService fileStorageService;
+
+    @BeforeEach
+    void setUp() {
+        s3Client = mock(S3Client.class);
+        s3Presigner = mock(S3Presigner.class);
+        bucketName = "mockName";
+        fileStorageService = new FileStorageService(s3Client, s3Presigner, bucketName);
+    }
+
+    @Nested
+    class UploadTests {
+        @DisplayName("파일 업로드 후 파일주소를 응답할 수 있다.")
+        @Test
+        void upload_file_and_return_fileurl() throws IOException {
+            //given
+            MultipartFile mockMultipartFile = mock(MultipartFile.class);
+            when(mockMultipartFile.getOriginalFilename()).thenReturn("test");
+            when(mockMultipartFile.getInputStream()).thenReturn(mock(InputStream.class));
+            when(mockMultipartFile.getSize()).thenReturn(1L);
+            when(s3Client.putObject(any(PutObjectRequest.class), any(RequestBody.class))).thenReturn(mock(PutObjectResponse.class));
+
+            PresignedGetObjectRequest presignedRequest = mock(PresignedGetObjectRequest.class);
+            when(presignedRequest.url()).thenReturn(URI.create("https://mock-bucket.s3.amazonaws.com/123_test.txt").toURL());
+            when(s3Presigner.presignGetObject(any(GetObjectPresignRequest.class))).thenReturn(presignedRequest);
+
+            //when
+            String result = fileStorageService.uploadFile(mockMultipartFile);
+
+            //then
+            assertThat(result).isNotNull();
+
+        }
+
+        @DisplayName("S3 업로드 실패 시 예외처리가 발생한다.")
+        @Test
+        void throws_exception_if_s3_upload_failed() {
+            // given
+            String fileUrl = "https://mock-bucket.s3.amazonaws.com/123_test.txt";
+            when(s3Client.deleteObject(any(DeleteObjectRequest.class)))
+                    .thenThrow(new RuntimeException("S3 delete failed"));
+
+            // when, then
+            assertThatThrownBy(() -> fileStorageService.deleteFile(fileUrl))
+                    .isInstanceOf(FileDeleteException.class) ;
+            verify(s3Client, times(1)).deleteObject(any(DeleteObjectRequest.class));
+        }
+    }
+
+    @Nested
+    @DisplayName("파일 삭제 테스트")
+    class DeleteTests {
+        @DisplayName("파일을 성공적으로 삭제한다")
+        @Test
+        void delete_file() {
+            // given
+            String fileUrl = "https://mock-bucket.s3.amazonaws.com/123_test.txt";
+            when(s3Client.deleteObject(any(DeleteObjectRequest.class))).thenReturn(null);
+
+            // when
+            fileStorageService.deleteFile(fileUrl);
+
+            // then
+            verify(s3Client, times(1)).deleteObject(any(DeleteObjectRequest.class));
+        }
+
+        @DisplayName("S3 삭제 실패 시 FileDeleteException을 던진다")
+        @Test
+        void throws_exception_if_s3_delete_failed() {
+            // given
+            String fileUrl = "https://mock-bucket.s3.amazonaws.com/123_test.txt";
+            when(s3Client.deleteObject(any(DeleteObjectRequest.class)))
+                    .thenThrow(new RuntimeException("S3 delete failed"));
+
+            // when, then
+            assertThatThrownBy(()-> fileStorageService.deleteFile(fileUrl))
+                    .isInstanceOf(FileDeleteException.class);
+            verify(s3Client, times(1)).deleteObject(any(DeleteObjectRequest.class));
+        }
+    }
+}

--- a/src/test/java/org/swyp/weddy/domain/storage/web/FileControllerTest.java
+++ b/src/test/java/org/swyp/weddy/domain/storage/web/FileControllerTest.java
@@ -1,0 +1,49 @@
+package org.swyp.weddy.domain.storage.web;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.web.multipart.MultipartFile;
+import org.swyp.weddy.domain.storage.service.FileStorageService;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.*;
+
+class FileControllerTest {
+    FileController fileController;
+    FileStorageService fileStorageService;
+    @BeforeEach
+    void setUp() {
+        fileStorageService = mock(FileStorageService.class);
+        fileController = new FileController(fileStorageService);
+    }
+
+    @DisplayName("파일 업로드를 요청을 받을 수 있다")
+    @Test
+    void upload_file() {
+        //given
+        MultipartFile mockMultipartFile = new MockMultipartFile("mock", "test".getBytes());
+        when(fileStorageService.uploadFile(mockMultipartFile)).thenReturn("test-url");
+
+        //when
+        var result = fileController.uploadFile(mockMultipartFile);
+
+        //then
+        assertEquals(200, result.getStatusCodeValue());
+        verify(fileStorageService, times(1)).uploadFile(mockMultipartFile);
+
+    }
+
+    @DisplayName("파일 삭제 요청을 받을 수 있다")
+    @Test
+    void delete_file() {
+        //given
+        String mockFileUrl = "test-url";
+        //when
+        fileStorageService.deleteFile(mockFileUrl);
+        //then
+        verify(fileStorageService, times(1)).deleteFile(mockFileUrl);
+
+    }
+}

--- a/src/test/resources/application.properties
+++ b/src/test/resources/application.properties
@@ -1,3 +1,5 @@
 jwt.secret= "dummyfor64bytesSecretKeydummyfor"
 kakao.auth.client= "dummy"
 kakao.auth.redirect= "dummy"
+aws.access-key-id: "dummy"
+aws.secret-access-key: "dummy"


### PR DESCRIPTION
## AWS S3를 이용하여 파일(이미지)업로드 기능
1. 업로드
  - 클라이언트에서 업로드 POST API를 호출하면, MultipartFile 타입으로 받아, s3에 업로드 요청합니다. 
  - 업로드 된 파일에 접근할 수 있는 url을 응답합니다.
2. 삭제
  - 클라이언트는 업로드 시 받았던 url을 가지고 DELETE API를 호출합니다.
  - url에서 파일의 이름인 fileKey를 추출하여 s3에 삭제요청합니다.

service 단에서 S3 API를 호출하다보니, 테스트가 많이 복잡합니다. 테스트하기 쉽게 구조를 만들고 싶은데, 의견있으면 남겨주세요.
