### PR TITLE
결혼 예정일 계산 기능을 구현한다

### DIFF
--- a/req.http
+++ b/req.http
@@ -62,3 +62,19 @@ Content-Type: application/json
   "memberId": "1",
   "id": "1"
 }
+
+###
+POST http://localhost:8080/checklist/1
+Content-Type: application/json
+
+{
+  "dDay": "2025-12-01"
+}
+
+###
+POST http://localhost:8080/checklist/1
+Content-Type: application/json
+
+{
+  "dDay": "2025-1201"
+}

--- a/src/main/java/org/swyp/weddy/domain/checklist/dao/ChecklistMapper.java
+++ b/src/main/java/org/swyp/weddy/domain/checklist/dao/ChecklistMapper.java
@@ -8,4 +8,6 @@ public interface ChecklistMapper {
     int insertChecklist(Checklist checklist);
 
     Checklist selectChecklistByMemberId(Long memberId);
+
+    int updateChecklist(Checklist checklist);
 }

--- a/src/main/java/org/swyp/weddy/domain/checklist/entity/Checklist.java
+++ b/src/main/java/org/swyp/weddy/domain/checklist/entity/Checklist.java
@@ -3,11 +3,12 @@ package org.swyp.weddy.domain.checklist.entity;
 import org.swyp.weddy.domain.checklist.service.dto.ChecklistDto;
 
 import java.sql.Timestamp;
+import java.time.LocalDateTime;
 
 public class Checklist {
     private Long id;
     private Long memberId;
-    private Integer dDay;
+    private LocalDateTime dDay;
     private Timestamp createdAt;
     private Timestamp updatedAt;
     private Boolean isDeleted;
@@ -15,7 +16,7 @@ public class Checklist {
     public Checklist() {
     }
 
-    public Checklist(Long id, Long memberId, Integer dDay, Timestamp createdAt, Timestamp updatedAt, Boolean isDeleted) {
+    public Checklist(Long id, Long memberId, LocalDateTime dDay, Timestamp createdAt, Timestamp updatedAt, Boolean isDeleted) {
         this.id = id;
         this.memberId = memberId;
         this.dDay = dDay;
@@ -24,7 +25,7 @@ public class Checklist {
         this.isDeleted = isDeleted;
     }
 
-    public Checklist(Long memberId, Integer dDay, Timestamp createdAt, Timestamp updatedAt, Boolean isDeleted) {
+    public Checklist(Long memberId, LocalDateTime dDay, Timestamp createdAt, Timestamp updatedAt, Boolean isDeleted) {
         this.memberId = memberId;
         this.dDay = dDay;
         this.createdAt = createdAt;
@@ -50,7 +51,7 @@ public class Checklist {
         return memberId;
     }
 
-    public Integer getdDay() {
+    public LocalDateTime getdDay() {
         return dDay;
     }
 }

--- a/src/main/java/org/swyp/weddy/domain/checklist/entity/Checklist.java
+++ b/src/main/java/org/swyp/weddy/domain/checklist/entity/Checklist.java
@@ -1,9 +1,12 @@
 package org.swyp.weddy.domain.checklist.entity;
 
+import org.swyp.weddy.domain.checklist.service.dto.ChecklistDdayAssignDto;
 import org.swyp.weddy.domain.checklist.service.dto.ChecklistDto;
 
 import java.sql.Timestamp;
+import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.LocalTime;
 
 public class Checklist {
     private Long id;
@@ -43,6 +46,16 @@ public class Checklist {
         );
     }
 
+    public static Checklist withNewDday(Checklist checklist, ChecklistDdayAssignDto dto) {
+        return new Checklist(
+                Long.valueOf(dto.getMemberId()),
+                convertDday(dto.getdDay()),
+                checklist.getCreatedAt(),
+                new Timestamp(System.currentTimeMillis()),
+                Boolean.FALSE
+        );
+    }
+
     public Long getId() {
         return id;
     }
@@ -53,5 +66,13 @@ public class Checklist {
 
     public LocalDateTime getdDay() {
         return dDay;
+    }
+
+    public Timestamp getCreatedAt() {
+        return createdAt;
+    }
+
+    static LocalDateTime convertDday(LocalDate localDate) {
+        return LocalDateTime.of(localDate, LocalTime.NOON);
     }
 }

--- a/src/main/java/org/swyp/weddy/domain/checklist/entity/Checklist.java
+++ b/src/main/java/org/swyp/weddy/domain/checklist/entity/Checklist.java
@@ -48,6 +48,7 @@ public class Checklist {
 
     public static Checklist withNewDday(Checklist checklist, ChecklistDdayAssignDto dto) {
         return new Checklist(
+                checklist.getId(),
                 Long.valueOf(dto.getMemberId()),
                 convertDday(dto.getdDay()),
                 checklist.getCreatedAt(),

--- a/src/main/java/org/swyp/weddy/domain/checklist/service/ChecklistService.java
+++ b/src/main/java/org/swyp/weddy/domain/checklist/service/ChecklistService.java
@@ -1,5 +1,6 @@
 package org.swyp.weddy.domain.checklist.service;
 
+import org.swyp.weddy.domain.checklist.service.dto.ChecklistDdayAssignDto;
 import org.swyp.weddy.domain.checklist.service.dto.ChecklistDto;
 import org.swyp.weddy.domain.checklist.web.response.ChecklistResponse;
 
@@ -9,4 +10,6 @@ public interface ChecklistService {
     boolean hasChecklist(ChecklistDto dto);
 
     ChecklistResponse findChecklist(ChecklistDto dto);
+
+    Long editDday(ChecklistDdayAssignDto dto);
 }

--- a/src/main/java/org/swyp/weddy/domain/checklist/service/ChecklistServiceImpl.java
+++ b/src/main/java/org/swyp/weddy/domain/checklist/service/ChecklistServiceImpl.java
@@ -53,6 +53,16 @@ public class ChecklistServiceImpl implements ChecklistService {
 
     @Override
     public Long editDday(ChecklistDdayAssignDto dto) {
-        return 0L;
+        Long memberId = Long.valueOf(dto.getMemberId());
+        Checklist checklist = mapper.selectChecklistByMemberId(memberId);
+
+        if (checklist == null) {
+            throw new ChecklistNotExistsException(ErrorCode.NOT_EXISTS);
+        }
+
+//        Checklist.withNewDday(checklist, dto);
+        mapper.updateChecklist(checklist);
+
+        return checklist.getId();
     }
 }

--- a/src/main/java/org/swyp/weddy/domain/checklist/service/ChecklistServiceImpl.java
+++ b/src/main/java/org/swyp/weddy/domain/checklist/service/ChecklistServiceImpl.java
@@ -7,6 +7,7 @@ import org.swyp.weddy.domain.checklist.dao.ChecklistMapper;
 import org.swyp.weddy.domain.checklist.entity.Checklist;
 import org.swyp.weddy.domain.checklist.exception.ChecklistAlreadyAssignedException;
 import org.swyp.weddy.domain.checklist.exception.ChecklistNotExistsException;
+import org.swyp.weddy.domain.checklist.service.dto.ChecklistDdayAssignDto;
 import org.swyp.weddy.domain.checklist.service.dto.ChecklistDto;
 import org.swyp.weddy.domain.checklist.web.response.ChecklistResponse;
 
@@ -48,5 +49,10 @@ public class ChecklistServiceImpl implements ChecklistService {
             throw new ChecklistNotExistsException(ErrorCode.NOT_EXISTS);
         }
         return ChecklistResponse.from(checklist);
+    }
+
+    @Override
+    public Long editDday(ChecklistDdayAssignDto dto) {
+        return 0L;
     }
 }

--- a/src/main/java/org/swyp/weddy/domain/checklist/service/ChecklistServiceImpl.java
+++ b/src/main/java/org/swyp/weddy/domain/checklist/service/ChecklistServiceImpl.java
@@ -51,6 +51,7 @@ public class ChecklistServiceImpl implements ChecklistService {
         return ChecklistResponse.from(checklist);
     }
 
+    @Transactional
     @Override
     public Long editDday(ChecklistDdayAssignDto dto) {
         Long memberId = Long.valueOf(dto.getMemberId());
@@ -60,8 +61,8 @@ public class ChecklistServiceImpl implements ChecklistService {
             throw new ChecklistNotExistsException(ErrorCode.NOT_EXISTS);
         }
 
-//        Checklist.withNewDday(checklist, dto);
-        mapper.updateChecklist(checklist);
+        Checklist checklistWithNewDday = Checklist.withNewDday(checklist, dto);
+        mapper.updateChecklist(checklistWithNewDday);
 
         return checklist.getId();
     }

--- a/src/main/java/org/swyp/weddy/domain/checklist/service/dto/ChecklistDdayAssignDto.java
+++ b/src/main/java/org/swyp/weddy/domain/checklist/service/dto/ChecklistDdayAssignDto.java
@@ -14,6 +14,6 @@ public class ChecklistDdayAssignDto {
     }
 
     public static ChecklistDdayAssignDto from(String memberId, ChecklistDdayAssignRequest request) {
-        return null;
+        return new ChecklistDdayAssignDto(memberId, request.getdDay());
     }
 }

--- a/src/main/java/org/swyp/weddy/domain/checklist/service/dto/ChecklistDdayAssignDto.java
+++ b/src/main/java/org/swyp/weddy/domain/checklist/service/dto/ChecklistDdayAssignDto.java
@@ -20,4 +20,8 @@ public class ChecklistDdayAssignDto {
     public String getMemberId() {
         return memberId;
     }
+
+    public LocalDate getdDay() {
+        return dDay;
+    }
 }

--- a/src/main/java/org/swyp/weddy/domain/checklist/service/dto/ChecklistDdayAssignDto.java
+++ b/src/main/java/org/swyp/weddy/domain/checklist/service/dto/ChecklistDdayAssignDto.java
@@ -16,4 +16,8 @@ public class ChecklistDdayAssignDto {
     public static ChecklistDdayAssignDto from(String memberId, ChecklistDdayAssignRequest request) {
         return new ChecklistDdayAssignDto(memberId, request.getdDay());
     }
+
+    public String getMemberId() {
+        return memberId;
+    }
 }

--- a/src/main/java/org/swyp/weddy/domain/checklist/service/dto/ChecklistDdayAssignDto.java
+++ b/src/main/java/org/swyp/weddy/domain/checklist/service/dto/ChecklistDdayAssignDto.java
@@ -2,7 +2,17 @@ package org.swyp.weddy.domain.checklist.service.dto;
 
 import org.swyp.weddy.domain.checklist.web.request.ChecklistDdayAssignRequest;
 
+import java.time.LocalDate;
+
 public class ChecklistDdayAssignDto {
+    private String memberId;
+    private LocalDate dDay;
+
+    public ChecklistDdayAssignDto(String memberId, LocalDate dDay) {
+        this.memberId = memberId;
+        this.dDay = dDay;
+    }
+
     public static ChecklistDdayAssignDto from(String memberId, ChecklistDdayAssignRequest request) {
         return null;
     }

--- a/src/main/java/org/swyp/weddy/domain/checklist/service/dto/ChecklistDdayAssignDto.java
+++ b/src/main/java/org/swyp/weddy/domain/checklist/service/dto/ChecklistDdayAssignDto.java
@@ -1,0 +1,9 @@
+package org.swyp.weddy.domain.checklist.service.dto;
+
+import org.swyp.weddy.domain.checklist.web.request.ChecklistDdayAssignRequest;
+
+public class ChecklistDdayAssignDto {
+    public static ChecklistDdayAssignDto from(String memberId, ChecklistDdayAssignRequest request) {
+        return null;
+    }
+}

--- a/src/main/java/org/swyp/weddy/domain/checklist/web/ChecklistController.java
+++ b/src/main/java/org/swyp/weddy/domain/checklist/web/ChecklistController.java
@@ -4,6 +4,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import org.swyp.weddy.domain.checklist.service.ChecklistService;
+import org.swyp.weddy.domain.checklist.service.dto.ChecklistDdayAssignDto;
 import org.swyp.weddy.domain.checklist.service.dto.ChecklistDto;
 import org.swyp.weddy.domain.checklist.web.request.ChecklistDdayAssignRequest;
 import org.swyp.weddy.domain.checklist.web.response.ChecklistResponse;
@@ -53,6 +54,8 @@ public class ChecklistController {
             @PathVariable("memberId") String memberId,
             @RequestBody ChecklistDdayAssignRequest request
     ) {
-        return null;
+        ChecklistDdayAssignDto dto = ChecklistDdayAssignDto.from(memberId, request);
+        checklistService.editDday(dto);
+        return ResponseEntity.ok().build();
     }
 }

--- a/src/main/java/org/swyp/weddy/domain/checklist/web/ChecklistController.java
+++ b/src/main/java/org/swyp/weddy/domain/checklist/web/ChecklistController.java
@@ -5,6 +5,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import org.swyp.weddy.domain.checklist.service.ChecklistService;
 import org.swyp.weddy.domain.checklist.service.dto.ChecklistDto;
+import org.swyp.weddy.domain.checklist.web.request.ChecklistDdayAssignRequest;
 import org.swyp.weddy.domain.checklist.web.response.ChecklistResponse;
 
 import java.util.Map;
@@ -45,5 +46,13 @@ public class ChecklistController {
         log.warn("hasChecklist: " + hasChecklist);
 
         return ResponseEntity.ok().build();
+    }
+
+    @PostMapping("/{memberId}")
+    public ResponseEntity<Void> assignWeddingDate(
+            @PathVariable("memberId") String memberId,
+            @RequestBody ChecklistDdayAssignRequest request
+    ) {
+        return null;
     }
 }

--- a/src/main/java/org/swyp/weddy/domain/checklist/web/request/ChecklistDdayAssignRequest.java
+++ b/src/main/java/org/swyp/weddy/domain/checklist/web/request/ChecklistDdayAssignRequest.java
@@ -1,0 +1,2 @@
+package org.swyp.weddy.domain.checklist.web.request;public class ChecklistDdayAssignRequest {
+}

--- a/src/main/java/org/swyp/weddy/domain/checklist/web/request/ChecklistDdayAssignRequest.java
+++ b/src/main/java/org/swyp/weddy/domain/checklist/web/request/ChecklistDdayAssignRequest.java
@@ -1,2 +1,4 @@
-package org.swyp.weddy.domain.checklist.web.request;public class ChecklistDdayAssignRequest {
+package org.swyp.weddy.domain.checklist.web.request;
+
+public class ChecklistDdayAssignRequest {
 }

--- a/src/main/java/org/swyp/weddy/domain/checklist/web/request/ChecklistDdayAssignRequest.java
+++ b/src/main/java/org/swyp/weddy/domain/checklist/web/request/ChecklistDdayAssignRequest.java
@@ -1,4 +1,18 @@
 package org.swyp.weddy.domain.checklist.web.request;
 
+import java.time.LocalDate;
+
 public class ChecklistDdayAssignRequest {
+    private LocalDate dDay;
+
+    public ChecklistDdayAssignRequest() {
+    }
+
+    public ChecklistDdayAssignRequest(LocalDate dDay) {
+        this.dDay = dDay;
+    }
+
+    public LocalDate getdDay() {
+        return dDay;
+    }
 }

--- a/src/main/java/org/swyp/weddy/domain/checklist/web/request/ChecklistDdayAssignRequest.java
+++ b/src/main/java/org/swyp/weddy/domain/checklist/web/request/ChecklistDdayAssignRequest.java
@@ -1,8 +1,13 @@
 package org.swyp.weddy.domain.checklist.web.request;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
 import java.time.LocalDate;
 
 public class ChecklistDdayAssignRequest {
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd", timezone = "Asia/Seoul")
+    @JsonProperty("dDay")
     private LocalDate dDay;
 
     public ChecklistDdayAssignRequest() {

--- a/src/main/java/org/swyp/weddy/domain/checklist/web/response/ChecklistResponse.java
+++ b/src/main/java/org/swyp/weddy/domain/checklist/web/response/ChecklistResponse.java
@@ -18,6 +18,14 @@ public class ChecklistResponse {
     }
 
     public static ChecklistResponse from(Checklist checklist) {
+        if (checklist.getdDay() == null) {
+            return new ChecklistResponse(
+                    checklist.getId(),
+                    String.valueOf(checklist.getMemberId()),
+                    null
+            );
+        }
+
         LocalDate weddingDate = ChecklistResponse.weddingDate(checklist);
         return new ChecklistResponse(
                 checklist.getId(),

--- a/src/main/java/org/swyp/weddy/domain/checklist/web/response/ChecklistResponse.java
+++ b/src/main/java/org/swyp/weddy/domain/checklist/web/response/ChecklistResponse.java
@@ -2,6 +2,10 @@ package org.swyp.weddy.domain.checklist.web.response;
 
 import org.swyp.weddy.domain.checklist.entity.Checklist;
 
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.temporal.ChronoUnit;
+
 public class ChecklistResponse {
     private final Long id;
     private final String memberId;
@@ -19,6 +23,23 @@ public class ChecklistResponse {
                 String.valueOf(checklist.getMemberId()),
                 0 //checklist.getdDay()
         );
+    }
+
+    public static LocalDate weddingDate(Checklist checklist) {
+        LocalDateTime weddingDateTime = checklist.getdDay();
+        return LocalDate.of(
+                weddingDateTime.getYear(),
+                weddingDateTime.getMonthValue(),
+                weddingDateTime.getDayOfMonth()
+        );
+    }
+
+    public static Long daysBeforeWedding(LocalDate weddingDate, LocalDate baseDate) {
+        if (baseDate == null) {
+            baseDate = LocalDate.now();
+        }
+
+        return ChronoUnit.DAYS.between(baseDate, weddingDate);
     }
 
     public Long getId() {

--- a/src/main/java/org/swyp/weddy/domain/checklist/web/response/ChecklistResponse.java
+++ b/src/main/java/org/swyp/weddy/domain/checklist/web/response/ChecklistResponse.java
@@ -9,19 +9,20 @@ import java.time.temporal.ChronoUnit;
 public class ChecklistResponse {
     private final Long id;
     private final String memberId;
-    private final Integer dDay;
+    private final Long dDay;
 
-    public ChecklistResponse(Long id, String memberId, Integer dDay) {
+    public ChecklistResponse(Long id, String memberId, Long dDay) {
         this.id = id;
         this.memberId = memberId;
         this.dDay = dDay;
     }
 
     public static ChecklistResponse from(Checklist checklist) {
+        LocalDate weddingDate = ChecklistResponse.weddingDate(checklist);
         return new ChecklistResponse(
                 checklist.getId(),
                 String.valueOf(checklist.getMemberId()),
-                0 //checklist.getdDay()
+                ChecklistResponse.daysBeforeWedding(weddingDate, LocalDate.now())
         );
     }
 
@@ -50,7 +51,7 @@ public class ChecklistResponse {
         return memberId;
     }
 
-    public Integer getdDay() {
+    public Long getdDay() {
         return dDay;
     }
 }

--- a/src/main/java/org/swyp/weddy/domain/checklist/web/response/ChecklistResponse.java
+++ b/src/main/java/org/swyp/weddy/domain/checklist/web/response/ChecklistResponse.java
@@ -17,7 +17,7 @@ public class ChecklistResponse {
         return new ChecklistResponse(
                 checklist.getId(),
                 String.valueOf(checklist.getMemberId()),
-                checklist.getdDay()
+                0 //checklist.getdDay()
         );
     }
 

--- a/src/main/resources/mapper/ChecklistMapper.xml
+++ b/src/main/resources/mapper/ChecklistMapper.xml
@@ -28,4 +28,13 @@
         FROM checklist
         WHERE member_id = #{memberId}
     </select>
+
+    <update id="updateChecklist" useGeneratedKeys="true" keyProperty="id"
+            parameterType="org.swyp.weddy.domain.checklist.entity.Checklist">
+        UPDATE checklist
+        SET d_day      = #{dDay},
+            updated_at = #{updatedAt}
+        WHERE member_id = #{memberId}
+          AND id = #{id};
+    </update>
 </mapper>

--- a/src/main/resources/sql/data.sql
+++ b/src/main/resources/sql/data.sql
@@ -16,7 +16,7 @@ VALUES ('test@example.com', '테스트 사용자', NULL, 'oauth_1234', 0);
 
 -- 2. checklist 테이블에 테스트 데이터 삽입
 INSERT INTO checklist (member_id, d_day, created_at, updated_at, is_deleted)
-VALUES (1, 100, NOW(), NOW(), 0);
+VALUES (1, '2030-03-01 12:00:00', NOW(), NOW(), 0);
 
 -- 3. large_category_item 및 small_category_item 데이터 삽입
 

--- a/src/main/resources/sql/schema.sql
+++ b/src/main/resources/sql/schema.sql
@@ -14,7 +14,7 @@ CREATE TABLE `checklist`
 (
     `id`         bigint PRIMARY KEY NOT NULL AUTO_INCREMENT,
     `member_id`  bigint             NOT NULL,
-    `d_day`      integer,
+    `d_day`      datetime,
     `created_at` timestamp,
     `updated_at` timestamp,
     `is_deleted` bool

--- a/src/test/java/org/swyp/weddy/domain/checklist/entity/ChecklistTest.java
+++ b/src/test/java/org/swyp/weddy/domain/checklist/entity/ChecklistTest.java
@@ -1,0 +1,30 @@
+package org.swyp.weddy.domain.checklist.entity;
+
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.sql.Timestamp;
+import java.time.LocalDateTime;
+
+class ChecklistTest {
+
+    @DisplayName("d-day 필드는 결혼 예정일 날짜 정보를 갖는다")
+    @Test
+    public void d_day_field_have_date_info() {
+        Checklist checklist = TestChecklist.from();
+        Assertions.assertThat(checklist.getdDay()).isInstanceOf(LocalDateTime.class);
+    }
+
+    private static class TestChecklist extends Checklist {
+        static Checklist from() {
+            return new Checklist(
+                    1L,
+                    LocalDateTime.now(),
+                    new Timestamp(System.currentTimeMillis()),
+                    null,
+                    Boolean.FALSE
+            );
+        }
+    }
+}

--- a/src/test/java/org/swyp/weddy/domain/checklist/entity/ChecklistTest.java
+++ b/src/test/java/org/swyp/weddy/domain/checklist/entity/ChecklistTest.java
@@ -5,6 +5,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 import java.sql.Timestamp;
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 
 class ChecklistTest {
@@ -14,6 +15,15 @@ class ChecklistTest {
     public void d_day_field_have_date_info() {
         Checklist checklist = TestChecklist.from();
         Assertions.assertThat(checklist.getdDay()).isInstanceOf(LocalDateTime.class);
+    }
+
+
+    @DisplayName("LocalDate 값을 LocalDateTime 값으로 변환할 수 있다")
+    @Test
+    public void convert_local_date_to_local_date_time() {
+        LocalDate weddingDate = LocalDate.now();
+        LocalDateTime localDateTime = Checklist.convertDday(weddingDate);
+        Assertions.assertThat(localDateTime).isNotNull();
     }
 
     private static class TestChecklist extends Checklist {

--- a/src/test/java/org/swyp/weddy/domain/checklist/service/ChecklistServiceTest.java
+++ b/src/test/java/org/swyp/weddy/domain/checklist/service/ChecklistServiceTest.java
@@ -98,14 +98,14 @@ class ChecklistServiceTest {
         @Test
         public void receive_assign_wedding_date_message() {
             ChecklistService service = new ChecklistServiceImpl(new FakeChecklistMapper());
-            service.editDday(new ChecklistDdayAssignDto("1", LocalDate.of(2025,12,1)));
+            service.editDday(new ChecklistDdayAssignDto("2", LocalDate.of(2025,12,1)));
         }
 
         @DisplayName("컨트롤러로부터 결혼 예정일 등록 요청을 받을 수 있다")
         @Test
         public void receive_assign_wedding_date_message_from_controller() {
             ChecklistDdayAssignDto dto = ChecklistDdayAssignDto.from(
-                    "1",
+                    "2",
                     new ChecklistDdayAssignRequest(LocalDate.of(2025, 12, 1))
             );
             assertThat(dto).isNotNull();

--- a/src/test/java/org/swyp/weddy/domain/checklist/service/ChecklistServiceTest.java
+++ b/src/test/java/org/swyp/weddy/domain/checklist/service/ChecklistServiceTest.java
@@ -102,13 +102,11 @@ class ChecklistServiceTest {
         @DisplayName("컨트롤러로부터 결혼 예정일 등록 요청을 받을 수 있다")
         @Test
         public void receive_assign_wedding_date_message_from_controller() {
-            ChecklistService service = new ChecklistServiceImpl(new FakeChecklistMapper());
             ChecklistDdayAssignDto dto = ChecklistDdayAssignDto.from(
                     "1",
                     new ChecklistDdayAssignRequest(LocalDate.of(2025, 12, 1))
             );
             assertThat(dto).isNotNull();
-            service.editDday(dto);
         }
     }
 

--- a/src/test/java/org/swyp/weddy/domain/checklist/service/ChecklistServiceTest.java
+++ b/src/test/java/org/swyp/weddy/domain/checklist/service/ChecklistServiceTest.java
@@ -2,6 +2,7 @@ package org.swyp.weddy.domain.checklist.service;
 
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.swyp.weddy.common.exception.ErrorCode;
 import org.swyp.weddy.domain.checklist.dao.ChecklistMapper;
@@ -11,6 +12,8 @@ import org.swyp.weddy.domain.checklist.exception.ChecklistNotExistsException;
 import org.swyp.weddy.domain.checklist.service.dto.ChecklistDdayAssignDto;
 import org.swyp.weddy.domain.checklist.service.dto.ChecklistDto;
 import org.swyp.weddy.domain.checklist.web.response.ChecklistResponse;
+
+import java.time.LocalDate;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -83,6 +86,17 @@ class ChecklistServiceTest {
                 ChecklistNotExistsException.class,
                 () -> service.findChecklist(dto)
         );
+    }
+
+    @DisplayName("editDday()")
+    @Nested
+    class EditDdayTest {
+        @DisplayName("결혼 예정일 등록 요청을 받을 수 있다")
+        @Test
+        public void receive_assign_wedding_date_message() {
+            ChecklistService service = new ChecklistServiceImpl(new FakeChecklistMapper());
+            service.editDday(new ChecklistDdayAssignDto("1", LocalDate.of(2025,12,1)));
+        }
     }
 
     private static class FakeChecklistService implements ChecklistService {

--- a/src/test/java/org/swyp/weddy/domain/checklist/service/ChecklistServiceTest.java
+++ b/src/test/java/org/swyp/weddy/domain/checklist/service/ChecklistServiceTest.java
@@ -189,6 +189,11 @@ class ChecklistServiceTest {
             ChecklistDto dto = ChecklistDto.from(memberId.toString());
             return Checklist.from(dto);
         }
+
+        @Override
+        public int updateChecklist(Checklist checklist) {
+            return 0;
+        }
     }
 
     private static class TestChecklist extends Checklist {

--- a/src/test/java/org/swyp/weddy/domain/checklist/service/ChecklistServiceTest.java
+++ b/src/test/java/org/swyp/weddy/domain/checklist/service/ChecklistServiceTest.java
@@ -8,6 +8,7 @@ import org.swyp.weddy.domain.checklist.dao.ChecklistMapper;
 import org.swyp.weddy.domain.checklist.entity.Checklist;
 import org.swyp.weddy.domain.checklist.exception.ChecklistAlreadyAssignedException;
 import org.swyp.weddy.domain.checklist.exception.ChecklistNotExistsException;
+import org.swyp.weddy.domain.checklist.service.dto.ChecklistDdayAssignDto;
 import org.swyp.weddy.domain.checklist.service.dto.ChecklistDto;
 import org.swyp.weddy.domain.checklist.web.response.ChecklistResponse;
 
@@ -117,6 +118,11 @@ class ChecklistServiceTest {
             }
 
             return ChecklistResponse.from(Checklist.from(dto));
+        }
+
+        @Override
+        public Long editDday(ChecklistDdayAssignDto dto) {
+            return 0L;
         }
     }
 

--- a/src/test/java/org/swyp/weddy/domain/checklist/service/ChecklistServiceTest.java
+++ b/src/test/java/org/swyp/weddy/domain/checklist/service/ChecklistServiceTest.java
@@ -14,7 +14,9 @@ import org.swyp.weddy.domain.checklist.service.dto.ChecklistDto;
 import org.swyp.weddy.domain.checklist.web.request.ChecklistDdayAssignRequest;
 import org.swyp.weddy.domain.checklist.web.response.ChecklistResponse;
 
+import java.sql.Timestamp;
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -108,6 +110,20 @@ class ChecklistServiceTest {
             );
             assertThat(dto).isNotNull();
         }
+
+        @DisplayName("결혼 예정일을 등록할 수 있다")
+        @Test
+        public void assign_wedding_date() {
+            ChecklistService service = new ChecklistServiceImpl(new FakeChecklistMapper());
+
+            Long l = service.editDday(
+                    new ChecklistDdayAssignDto(
+                            "2",
+                            LocalDate.of(2025, 12, 1)
+                    )
+            );
+            assertThat(l).isEqualTo(2L);
+        }
     }
 
     private static class FakeChecklistService implements ChecklistService {
@@ -162,12 +178,29 @@ class ChecklistServiceTest {
 
         @Override
         public Checklist selectChecklistByMemberId(Long memberId) {
+            if (memberId == 2L) {
+                return TestChecklist.from();
+            }
+
             if (!hasChecklist) {
                 return null;
             }
 
             ChecklistDto dto = ChecklistDto.from(memberId.toString());
             return Checklist.from(dto);
+        }
+    }
+
+    private static class TestChecklist extends Checklist {
+        static Checklist from() {
+            return new Checklist(
+                    2L,
+                    1L,
+                    LocalDateTime.now(),
+                    new Timestamp(System.currentTimeMillis()),
+                    null,
+                    Boolean.FALSE
+            );
         }
     }
 }

--- a/src/test/java/org/swyp/weddy/domain/checklist/service/ChecklistServiceTest.java
+++ b/src/test/java/org/swyp/weddy/domain/checklist/service/ChecklistServiceTest.java
@@ -11,6 +11,7 @@ import org.swyp.weddy.domain.checklist.exception.ChecklistAlreadyAssignedExcepti
 import org.swyp.weddy.domain.checklist.exception.ChecklistNotExistsException;
 import org.swyp.weddy.domain.checklist.service.dto.ChecklistDdayAssignDto;
 import org.swyp.weddy.domain.checklist.service.dto.ChecklistDto;
+import org.swyp.weddy.domain.checklist.web.request.ChecklistDdayAssignRequest;
 import org.swyp.weddy.domain.checklist.web.response.ChecklistResponse;
 
 import java.time.LocalDate;
@@ -96,6 +97,18 @@ class ChecklistServiceTest {
         public void receive_assign_wedding_date_message() {
             ChecklistService service = new ChecklistServiceImpl(new FakeChecklistMapper());
             service.editDday(new ChecklistDdayAssignDto("1", LocalDate.of(2025,12,1)));
+        }
+
+        @DisplayName("컨트롤러로부터 결혼 예정일 등록 요청을 받을 수 있다")
+        @Test
+        public void receive_assign_wedding_date_message_from_controller() {
+            ChecklistService service = new ChecklistServiceImpl(new FakeChecklistMapper());
+            ChecklistDdayAssignDto dto = ChecklistDdayAssignDto.from(
+                    "1",
+                    new ChecklistDdayAssignRequest(LocalDate.of(2025, 12, 1))
+            );
+            assertThat(dto).isNotNull();
+            service.editDday(dto);
         }
     }
 

--- a/src/test/java/org/swyp/weddy/domain/checklist/web/ChecklistControllerTest.java
+++ b/src/test/java/org/swyp/weddy/domain/checklist/web/ChecklistControllerTest.java
@@ -1,0 +1,41 @@
+package org.swyp.weddy.domain.checklist.web;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.swyp.weddy.domain.checklist.service.ChecklistService;
+import org.swyp.weddy.domain.checklist.service.dto.ChecklistDto;
+import org.swyp.weddy.domain.checklist.web.request.ChecklistDdayAssignRequest;
+import org.swyp.weddy.domain.checklist.web.response.ChecklistResponse;
+
+class ChecklistControllerTest {
+
+    @DisplayName("assignWeddingDate()")
+    @Nested
+    class AssignWeddingDateTest {
+        @DisplayName("결혼 예정일 등록 요청을 받을 수 있다")
+        @Test
+        public void receive_assign_wedding_date_message() {
+            ChecklistController controller = new ChecklistController(new FakeChecklistService());
+            controller.assignWeddingDate("1", new ChecklistDdayAssignRequest());
+        }
+    }
+
+    private static class FakeChecklistService implements ChecklistService {
+
+        @Override
+        public Long assignChecklist(ChecklistDto dto) {
+            return 0L;
+        }
+
+        @Override
+        public boolean hasChecklist(ChecklistDto dto) {
+            return false;
+        }
+
+        @Override
+        public ChecklistResponse findChecklist(ChecklistDto dto) {
+            return null;
+        }
+    }
+}

--- a/src/test/java/org/swyp/weddy/domain/checklist/web/ChecklistControllerTest.java
+++ b/src/test/java/org/swyp/weddy/domain/checklist/web/ChecklistControllerTest.java
@@ -8,6 +8,8 @@ import org.swyp.weddy.domain.checklist.service.dto.ChecklistDto;
 import org.swyp.weddy.domain.checklist.web.request.ChecklistDdayAssignRequest;
 import org.swyp.weddy.domain.checklist.web.response.ChecklistResponse;
 
+import java.time.LocalDate;
+
 class ChecklistControllerTest {
 
     @DisplayName("assignWeddingDate()")
@@ -19,6 +21,14 @@ class ChecklistControllerTest {
             ChecklistController controller = new ChecklistController(new FakeChecklistService());
             controller.assignWeddingDate("1", new ChecklistDdayAssignRequest());
         }
+
+        @DisplayName("요청은 날짜 정보를 포함한다")
+        @Test
+        public void date_in_message_follows_format() {
+            ChecklistController controller = new ChecklistController(new FakeChecklistService());
+            controller.assignWeddingDate("1", new ChecklistDdayAssignRequest(LocalDate.of(2025, 12, 1)));
+        }
+
     }
 
     private static class FakeChecklistService implements ChecklistService {

--- a/src/test/java/org/swyp/weddy/domain/checklist/web/ChecklistControllerTest.java
+++ b/src/test/java/org/swyp/weddy/domain/checklist/web/ChecklistControllerTest.java
@@ -4,11 +4,14 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.swyp.weddy.domain.checklist.service.ChecklistService;
+import org.swyp.weddy.domain.checklist.service.dto.ChecklistDdayAssignDto;
 import org.swyp.weddy.domain.checklist.service.dto.ChecklistDto;
 import org.swyp.weddy.domain.checklist.web.request.ChecklistDdayAssignRequest;
 import org.swyp.weddy.domain.checklist.web.response.ChecklistResponse;
 
 import java.time.LocalDate;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 class ChecklistControllerTest {
 
@@ -29,6 +32,14 @@ class ChecklistControllerTest {
             controller.assignWeddingDate("1", new ChecklistDdayAssignRequest(LocalDate.of(2025, 12, 1)));
         }
 
+        @DisplayName("결혼 예정일 등록 결과를 반환할 수 있다")
+        @Test
+        public void returns_assign_wedding_date() {
+            ChecklistController controller = new ChecklistController(new FakeChecklistService());
+            assertThat(
+                    controller.assignWeddingDate("1", new ChecklistDdayAssignRequest())
+            ).isNotNull();
+        }
     }
 
     private static class FakeChecklistService implements ChecklistService {

--- a/src/test/java/org/swyp/weddy/domain/checklist/web/ChecklistControllerTest.java
+++ b/src/test/java/org/swyp/weddy/domain/checklist/web/ChecklistControllerTest.java
@@ -58,5 +58,10 @@ class ChecklistControllerTest {
         public ChecklistResponse findChecklist(ChecklistDto dto) {
             return null;
         }
+
+        @Override
+        public Long editDday(ChecklistDdayAssignDto dto) {
+            return 0L;
+        }
     }
 }

--- a/src/test/java/org/swyp/weddy/domain/checklist/web/LargeCatControllerTest.java
+++ b/src/test/java/org/swyp/weddy/domain/checklist/web/LargeCatControllerTest.java
@@ -242,9 +242,9 @@ class LargeCatControllerTest {
         @Override
         public ChecklistResponse findChecklist(ChecklistDto dto) {
             if (dto.getMemberId().equals("-1")) {
-                return new ChecklistResponse(-1L, "1L", 100);
+                return new ChecklistResponse(-1L, "1L", 100L);
             }
-            return new ChecklistResponse(1L, "1L", 100);
+            return new ChecklistResponse(1L, "1L", 100L);
         }
     }
 

--- a/src/test/java/org/swyp/weddy/domain/checklist/web/LargeCatControllerTest.java
+++ b/src/test/java/org/swyp/weddy/domain/checklist/web/LargeCatControllerTest.java
@@ -246,6 +246,11 @@ class LargeCatControllerTest {
             }
             return new ChecklistResponse(1L, "1L", 100L);
         }
+
+        @Override
+        public Long editDday(ChecklistDdayAssignDto dto) {
+            return 0L;
+        }
     }
 
     private static class FakeFilteringService implements FilteringService {

--- a/src/test/java/org/swyp/weddy/domain/checklist/web/response/ChecklistResponseTest.java
+++ b/src/test/java/org/swyp/weddy/domain/checklist/web/response/ChecklistResponseTest.java
@@ -3,12 +3,8 @@ package org.swyp.weddy.domain.checklist.web.response;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
-import org.swyp.weddy.domain.checklist.entity.Checklist;
 
-import java.sql.Timestamp;
 import java.time.LocalDate;
-import java.time.LocalDateTime;
-import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -17,38 +13,13 @@ import static org.assertj.core.api.Assertions.assertThat;
 class ChecklistResponseTest {
 
     @DisplayName("결혼까지 남은 일자를 계산할 수 있다")
-    @Test
-    public void compute_days_left_before_wedding() {
-        Checklist checklist = TestChecklist.from();
-        LocalDate weddingDate = ChecklistResponse.weddingDate(checklist);
-        LocalDate today = LocalDate.of(2025,3,1);
-
-        Long dDayCount = ChecklistResponse.daysBeforeWedding(weddingDate, today);
-
-        assertThat(dDayCount).isInstanceOf(Long.class);
-        assertThat(dDayCount).isGreaterThan(0);
-    }
-
-    private static class TestChecklist extends Checklist {
-        static Checklist from() {
-            return new Checklist(
-                    1L,
-                    LocalDateTime.parse("2025-12-01T00:00:00"),
-                    new Timestamp(System.currentTimeMillis()),
-                    null,
-                    Boolean.FALSE
-            );
-        }
-    }
-
-    @DisplayName("두 날짜 사이 일수를 계산할 수 있다")
     @Nested
-    class DayCountComputeTest {
+    class DaysBeforeWeddingComputeTest {
         @DisplayName("결혼 당일")
         @Test
         public void when_wedding_day() {
             assertThat(
-                    ChronoUnit.DAYS.between(
+                    ChecklistResponse.daysBeforeWedding(
                             LocalDate.of(2025, 3, 1),
                             LocalDate.of(2025, 3, 1)
                     )
@@ -59,9 +30,9 @@ class ChecklistResponseTest {
         @Test
         public void one_day_before_wedding() {
             assertThat(
-                    ChronoUnit.DAYS.between(
-                            LocalDate.of(2025, 3, 1),
-                            LocalDate.of(2025, 3, 2)
+                    ChecklistResponse.daysBeforeWedding(
+                            LocalDate.of(2025, 3, 2),
+                            LocalDate.of(2025, 3, 1)
                     )
             ).isEqualTo(1);
         }
@@ -79,9 +50,9 @@ class ChecklistResponseTest {
                 Integer weddingMonth = integerList.get(1);
                 Long expected = Long.valueOf(integerList.get(2));
                 assertThat(
-                        ChronoUnit.DAYS.between(
-                                LocalDate.of(2025, todayMonth, 1),
-                                LocalDate.of(2025, weddingMonth, 1)
+                        ChecklistResponse.daysBeforeWedding(
+                                LocalDate.of(2025, weddingMonth, 1),
+                                LocalDate.of(2025, todayMonth, 1)
                         )
                 ).isEqualTo(expected);
             }
@@ -91,9 +62,9 @@ class ChecklistResponseTest {
         @Test
         public void one_year_before_wedding() {
             assertThat(
-                    ChronoUnit.DAYS.between(
-                            LocalDate.of(2025, 3, 1),
-                            LocalDate.of(2026, 3, 1)
+                    ChecklistResponse.daysBeforeWedding(
+                            LocalDate.of(2026, 3, 1),
+                            LocalDate.of(2025, 3, 1)
                     )
             ).isEqualTo(365);
         }

--- a/src/test/java/org/swyp/weddy/domain/checklist/web/response/ChecklistResponseTest.java
+++ b/src/test/java/org/swyp/weddy/domain/checklist/web/response/ChecklistResponseTest.java
@@ -1,0 +1,101 @@
+package org.swyp.weddy.domain.checklist.web.response;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.swyp.weddy.domain.checklist.entity.Checklist;
+
+import java.sql.Timestamp;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.temporal.ChronoUnit;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class ChecklistResponseTest {
+
+    @DisplayName("결혼까지 남은 일자를 계산할 수 있다")
+    @Test
+    public void compute_days_left_before_wedding() {
+        Checklist checklist = TestChecklist.from();
+        LocalDate weddingDate = ChecklistResponse.weddingDate(checklist);
+        LocalDate today = LocalDate.of(2025,3,1);
+
+        Long dDayCount = ChecklistResponse.daysBeforeWedding(weddingDate, today);
+
+        assertThat(dDayCount).isInstanceOf(Long.class);
+        assertThat(dDayCount).isGreaterThan(0);
+    }
+
+    private static class TestChecklist extends Checklist {
+        static Checklist from() {
+            return new Checklist(
+                    1L,
+                    LocalDateTime.parse("2025-12-01T00:00:00"),
+                    new Timestamp(System.currentTimeMillis()),
+                    null,
+                    Boolean.FALSE
+            );
+        }
+    }
+
+    @DisplayName("두 날짜 사이 일수를 계산할 수 있다")
+    @Nested
+    class DayCountComputeTest {
+        @DisplayName("결혼 당일")
+        @Test
+        public void when_wedding_day() {
+            assertThat(
+                    ChronoUnit.DAYS.between(
+                            LocalDate.of(2025, 3, 1),
+                            LocalDate.of(2025, 3, 1)
+                    )
+            ).isEqualTo(0);
+        }
+
+        @DisplayName("결혼 전날")
+        @Test
+        public void one_day_before_wedding() {
+            assertThat(
+                    ChronoUnit.DAYS.between(
+                            LocalDate.of(2025, 3, 1),
+                            LocalDate.of(2025, 3, 2)
+                    )
+            ).isEqualTo(1);
+        }
+
+        @DisplayName("결혼 1개월 전")
+        @Test
+        public void one_month_before_wedding() {
+            List<List<Integer>> integerLists = new ArrayList<List<Integer>>();
+            integerLists.add(List.of(2,3,28));
+            integerLists.add(List.of(3,4,31));
+            integerLists.add(List.of(4,5,30));
+
+            for (List<Integer> integerList : integerLists) {
+                Integer todayMonth = integerList.get(0);
+                Integer weddingMonth = integerList.get(1);
+                Long expected = Long.valueOf(integerList.get(2));
+                assertThat(
+                        ChronoUnit.DAYS.between(
+                                LocalDate.of(2025, todayMonth, 1),
+                                LocalDate.of(2025, weddingMonth, 1)
+                        )
+                ).isEqualTo(expected);
+            }
+        }
+
+        @DisplayName("결혼 1년 전")
+        @Test
+        public void one_year_before_wedding() {
+            assertThat(
+                    ChronoUnit.DAYS.between(
+                            LocalDate.of(2025, 3, 1),
+                            LocalDate.of(2026, 3, 1)
+                    )
+            ).isEqualTo(365);
+        }
+    }
+}

--- a/src/test/java/org/swyp/weddy/slow/ChecklistSlowTest.java
+++ b/src/test/java/org/swyp/weddy/slow/ChecklistSlowTest.java
@@ -1,0 +1,49 @@
+package org.swyp.weddy.slow;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.transaction.annotation.Transactional;
+import org.swyp.weddy.domain.checklist.dao.ChecklistMapper;
+import org.swyp.weddy.domain.checklist.entity.Checklist;
+import org.swyp.weddy.domain.checklist.service.ChecklistService;
+import org.swyp.weddy.domain.checklist.service.dto.ChecklistDdayAssignDto;
+
+import java.time.LocalDate;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@Tag("slow")
+@Transactional
+@SpringBootTest
+public class ChecklistSlowTest {
+    @Autowired
+    private ChecklistService checklistService;
+    @Autowired
+    private ChecklistMapper checklistMapper;
+    @Autowired
+    private JdbcTemplate jdbcTemplate;
+
+    @DisplayName("checklist의 d_day 컬럼 값을 바꿀 수 있다")
+    @Test
+    void returns_empty_list_when_no_result_in_select_query() {
+        jdbcTemplate.update("""
+                update checklist
+                set d_day = null
+                where id = 1
+                """);
+
+        Checklist checklist = checklistMapper.selectChecklistByMemberId(1L);
+        ChecklistDdayAssignDto dto = new ChecklistDdayAssignDto("1", LocalDate.now());
+        Checklist editedChecklist = Checklist.withNewDday(checklist, dto);
+        int editedId = checklistMapper.updateChecklist(editedChecklist);
+
+        assertThat(editedId).isEqualTo(1);
+
+        Checklist check = checklistMapper.selectChecklistByMemberId(Long.valueOf(editedId));
+        assertThat(check.getdDay()).isNotNull();
+    }
+}


### PR DESCRIPTION
체크리스트를 가져올 때
- checklist.d_day 컬럼의 값이 설정되어 있으면
- 결혼까지 얼마나 남았는지 계산합니다

d_day 컬럼 타입을 datetime으로 변경합니다
- d-day 관련 로직에 시간이 필요한 경우가 생긴다고 하면,
- 운영 후 db에 값이 들어간 상태에서 컬럼 타입을 바꾸는 게 쉽지 않을 것 같았고
- datetime으로 정의하더라도, 소스에서 date 형식으로 바꿔 쓰는 게 어렵지 않아 보여서 정했습니다

d_day 설정 api는 이 pr에 추가로 구현해 올릴 예정입니다