### PR TITLE
대시보드 관련 기능

### DIFF
--- a/src/main/java/org/swyp/weddy/domain/checklist/entity/SmallCatItem.java
+++ b/src/main/java/org/swyp/weddy/domain/checklist/entity/SmallCatItem.java
@@ -28,6 +28,18 @@ public class SmallCatItem {
     private Long sequence;
     private String attachedFileUrl;
 
+    public SmallCatItem(Long id, Long largeCatItemId, String title, Date dueDate, String assigneeName, String body, String statusName, Long amount, String attachedFileUrl) {
+        this.id = id;
+        this.largeCatItemId = largeCatItemId;
+        this.title = title;
+        this.dueDate = dueDate;
+        this.assigneeName = assigneeName;
+        this.body = body;
+        this.statusName = statusName;
+        this.amount = amount;
+        this.attachedFileUrl = attachedFileUrl;
+    }
+
     public static SmallCatItem from(SmallCatItemDto dto) {
         return new SmallCatItem(
                 dto.getId(),

--- a/src/main/java/org/swyp/weddy/domain/checklist/entity/SmallCatItemPreview.java
+++ b/src/main/java/org/swyp/weddy/domain/checklist/entity/SmallCatItemPreview.java
@@ -17,6 +17,7 @@ public class SmallCatItemPreview {
     private Date dueDate;
     private String assigneeName;
     private String statusName;
+    private Long amount;
     private Long sequence;
 
     public SmallCatItemPreview(Long id, Long largeCatItemId, String title, Date dueDate, String assigneeName, String statusName) {
@@ -26,5 +27,14 @@ public class SmallCatItemPreview {
         this.dueDate = dueDate;
         this.assigneeName = assigneeName;
         this.statusName = statusName;
+    }
+    public SmallCatItemPreview(Long id, Long largeCatItemId, String title, Date dueDate, String assigneeName, String statusName, Long amount) {
+        this.id = id;
+        this.largeCatItemId = largeCatItemId;
+        this.title = title;
+        this.dueDate = dueDate;
+        this.assigneeName = assigneeName;
+        this.statusName = statusName;
+        this.amount = amount;
     }
 }

--- a/src/main/java/org/swyp/weddy/domain/checklist/web/response/SmallCatItemPreviewResponse.java
+++ b/src/main/java/org/swyp/weddy/domain/checklist/web/response/SmallCatItemPreviewResponse.java
@@ -3,11 +3,9 @@ package org.swyp.weddy.domain.checklist.web.response;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-
-import java.util.Date;
-
 import org.swyp.weddy.domain.checklist.entity.SmallCatItemPreview;
 
+import java.util.Date;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -21,6 +19,8 @@ public class SmallCatItemPreviewResponse {
     private Date dueDate;
     private String assigneeName;
     private String statusName;
+    private Long amount;
+
 
     public static List<SmallCatItemPreviewResponse> from(List<SmallCatItemPreview> SmallCatItemPreviews) {
         return SmallCatItemPreviews.stream()
@@ -30,7 +30,8 @@ public class SmallCatItemPreviewResponse {
                         item.getTitle(),
                         item.getDueDate(),
                         item.getAssigneeName(),
-                        item.getStatusName()
+                        item.getStatusName(),
+                        item.getAmount()
                 ))
                 .collect(Collectors.toList());
     }

--- a/src/main/resources/mapper/SmallCatMapper.xml
+++ b/src/main/resources/mapper/SmallCatMapper.xml
@@ -5,7 +5,7 @@
 
     <!-- 프리뷰 컬럼 조회 -->
     <select id="selectItemPreviews" resultType="org.swyp.weddy.domain.checklist.entity.SmallCatItemPreview">
-        SELECT small.id, small.large_category_item_id, small.title, small.due_date, assignee.name, status.name "status_name", small.sequence
+        SELECT small.id, small.large_category_item_id, small.title, small.due_date, assignee.name, status.name "status_name", small.amount
           FROM small_category_item small
           JOIN large_category_item large ON small.large_category_item_id = large.id
           JOIN checklist ON large.checklist_id = checklist.id

--- a/src/main/resources/mapper/SmallCatMapper.xml
+++ b/src/main/resources/mapper/SmallCatMapper.xml
@@ -19,7 +19,7 @@
 
     <!-- 모든 컬럼 조회 -->
     <select id="selectItem" resultType="org.swyp.weddy.domain.checklist.entity.SmallCatItem">
-        SELECT small.id, small.large_category_item_id, small.title, small.due_date, assignee.name, small.body, status.name "status_name", small.amount, small.sequence, small.attached_file_url
+        SELECT small.id, small.large_category_item_id, small.title, small.due_date, assignee.name, small.body, status.name "status_name", small.amount, small.attached_file_url
           FROM small_category_item small
           JOIN large_category_item large ON small.large_category_item_id = large.id
           JOIN checklist ON large.checklist_id = checklist.id

--- a/src/test/java/org/swyp/weddy/domain/checklist/service/FilteringServiceTest.java
+++ b/src/test/java/org/swyp/weddy/domain/checklist/service/FilteringServiceTest.java
@@ -72,7 +72,8 @@ class FilteringServiceTest {
                     "",
                     null,
                     null,
-                    statusName
+                    statusName,
+                    1L
             );
         }
     }

--- a/src/test/java/org/swyp/weddy/domain/checklist/service/LargeCatServiceTest.java
+++ b/src/test/java/org/swyp/weddy/domain/checklist/service/LargeCatServiceTest.java
@@ -199,9 +199,9 @@ class LargeCatServiceTest {
             }
 
             return List.of(
-                    new SmallCatItemPreviewResponse(1L, 1L, "t1", new Date(), "세훈", "진행중"),
-                    new SmallCatItemPreviewResponse(2L, 1L, "t2", new Date(), "세순", "완료"),
-                    new SmallCatItemPreviewResponse(3L, 1L, "t3", new Date(), "세준", "진행중")
+                    new SmallCatItemPreviewResponse(1L, 1L, "t1", new Date(), "세훈", "진행중", 1L),
+                    new SmallCatItemPreviewResponse(2L, 1L, "t2", new Date(), "세순", "완료", 1L),
+                    new SmallCatItemPreviewResponse(3L, 1L, "t3", new Date(), "세준", "진행중", 1L)
             );
         }
 


### PR DESCRIPTION
대시보드의 "결혼예산"항목에 금액이 표시될 수 있도록 API를 보완했습니다.

- 기존 API에서 SmallCatItemPreviews에 '금액'항목을 추가해 응답하도록 했습니다.
- 쿼리 변경하며, 조회시 불필요한 컬럼이 있어 제거했습니다.

