### PR TITLE
refactor: 쿼리 속도 개선을 위한  인덱스 추가

### DIFF
--- a/src/main/java/org/swyp/weddy/domain/checklist/dao/SmallCatMapper.java
+++ b/src/main/java/org/swyp/weddy/domain/checklist/dao/SmallCatMapper.java
@@ -13,6 +13,7 @@ public interface SmallCatMapper {
 
     List<SmallCatItemPreview> selectItemPreviews(@Param("checklistId")Long checklistId, @Param("largeCatItemId")Long largeCatItemId);
     List<SmallCatItemPreview> selectItemPreviewsBy(SmallCatItemSelectDto dto);
+    List<SmallCatItemPreview> findItemPreviewsByChecklistId(@Param("checklistId")Long checklistId);
     SmallCatItem selectItem(@Param("checklistId")Long checklistId, @Param("largeCatItemId")Long largeCatItemId, @Param("smallCatItemId")Long smallCatItemId);
     Long insertItem(SmallCatItem smallCatItem);
 

--- a/src/main/java/org/swyp/weddy/domain/checklist/service/LargeCatServiceImpl.java
+++ b/src/main/java/org/swyp/weddy/domain/checklist/service/LargeCatServiceImpl.java
@@ -117,15 +117,14 @@ public class LargeCatServiceImpl implements LargeCatService {
             throw new LargeCatItemNotExistsException(ErrorCode.NOT_EXISTS);
         }
 
+        List<SmallCatItemPreviewResponse> itemPreviews = smallCatService.findItemPreviewsByChecklistId(checklistId);
+
         List<LargeCatItemResponse> result = new ArrayList<>();
         for (LargeCatItem item : allItems) {
-            List<SmallCatItemPreviewResponse> itemPreviews = smallCatService.findItemPreviews(
-                    checklistId, item.getId()
-            );
-
-            LargeCatItemResponse itemWithSmallItems = LargeCatItemResponse.from(item).withSmallCatItems(itemPreviews);
+            LargeCatItemResponse itemWithSmallItems = LargeCatItemResponse.from(item).withAllSmallCatItems(itemPreviews);
             result.add(itemWithSmallItems);
         }
+
 
         return result;
     }

--- a/src/main/java/org/swyp/weddy/domain/checklist/service/SmallCatService.java
+++ b/src/main/java/org/swyp/weddy/domain/checklist/service/SmallCatService.java
@@ -11,6 +11,8 @@ import java.util.List;
 public interface SmallCatService {
 
     List<SmallCatItemPreviewResponse> findItemPreviews(Long checklistId, Long largeCatItemId);
+
+    List<SmallCatItemPreviewResponse> findItemPreviewsByChecklistId(Long checklistId);
     SmallCatItemResponse findItem(Long checklistId, Long largeCatItemId, Long smallCatItemId);
 
     Long addItem(SmallCatItemDto dto);

--- a/src/main/java/org/swyp/weddy/domain/checklist/service/SmallCatServiceImpl.java
+++ b/src/main/java/org/swyp/weddy/domain/checklist/service/SmallCatServiceImpl.java
@@ -39,6 +39,14 @@ public class SmallCatServiceImpl implements SmallCatService {
     }
 
     @Override
+    public List<SmallCatItemPreviewResponse> findItemPreviewsByChecklistId(Long checklistId) {
+        List<SmallCatItemPreview> smallCatItemPreviews = mapper.findItemPreviewsByChecklistId(checklistId);
+
+        List<SmallCatItemPreviewResponse> smallCatItemPreviewResponses = SmallCatItemPreviewResponse.from(smallCatItemPreviews);
+        return smallCatItemPreviewResponses;
+    }
+
+    @Override
     public SmallCatItemResponse findItem(Long checklistId, Long largeCatItemId, Long smallCatItemId) {
         SmallCatItem smallCatItems = mapper.selectItem(checklistId, largeCatItemId, smallCatItemId);
 

--- a/src/main/java/org/swyp/weddy/domain/checklist/web/LargeCatController.java
+++ b/src/main/java/org/swyp/weddy/domain/checklist/web/LargeCatController.java
@@ -2,7 +2,6 @@ package org.swyp.weddy.domain.checklist.web;
 
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
-import org.springframework.util.StopWatch;
 import org.springframework.web.bind.annotation.*;
 import org.swyp.weddy.domain.checklist.service.ChecklistService;
 import org.swyp.weddy.domain.checklist.service.FilteringService;
@@ -54,20 +53,9 @@ public class LargeCatController implements LargeCatApiSpec {
         ChecklistDto dto = ChecklistDto.from(memberId);
         ChecklistResponse checklist = checklistService.findChecklist(dto);
 
-        StopWatch stopWatch = new StopWatch();
-        stopWatch.start();
-
         Long checklistId = checklist.getId();
         if (itemStatuses.equals("") && itemAssignees.equals("")) {
             List<LargeCatItemResponse> allItems = largeCatService.findAllItems(checklistId);
-
-            stopWatch.stop();
-
-            System.out.println("Execution time: " + stopWatch.getTotalTimeMillis() + " ms");
-            // 또는 더 자세한 출력
-            log.debug(stopWatch.prettyPrint());
-            System.out.println(stopWatch.prettyPrint());
-
             return ResponseEntity.ok().body(allItems);
         }
 

--- a/src/main/java/org/swyp/weddy/domain/checklist/web/LargeCatController.java
+++ b/src/main/java/org/swyp/weddy/domain/checklist/web/LargeCatController.java
@@ -2,6 +2,7 @@ package org.swyp.weddy.domain.checklist.web;
 
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
+import org.springframework.util.StopWatch;
 import org.springframework.web.bind.annotation.*;
 import org.swyp.weddy.domain.checklist.service.ChecklistService;
 import org.swyp.weddy.domain.checklist.service.FilteringService;
@@ -53,9 +54,20 @@ public class LargeCatController implements LargeCatApiSpec {
         ChecklistDto dto = ChecklistDto.from(memberId);
         ChecklistResponse checklist = checklistService.findChecklist(dto);
 
+        StopWatch stopWatch = new StopWatch();
+        stopWatch.start();
+
         Long checklistId = checklist.getId();
         if (itemStatuses.equals("") && itemAssignees.equals("")) {
             List<LargeCatItemResponse> allItems = largeCatService.findAllItems(checklistId);
+
+            stopWatch.stop();
+
+            System.out.println("Execution time: " + stopWatch.getTotalTimeMillis() + " ms");
+            // 또는 더 자세한 출력
+            log.debug(stopWatch.prettyPrint());
+            System.out.println(stopWatch.prettyPrint());
+
             return ResponseEntity.ok().body(allItems);
         }
 

--- a/src/main/java/org/swyp/weddy/domain/checklist/web/response/LargeCatItemResponse.java
+++ b/src/main/java/org/swyp/weddy/domain/checklist/web/response/LargeCatItemResponse.java
@@ -4,6 +4,7 @@ import org.swyp.weddy.domain.checklist.entity.LargeCatItem;
 
 import java.util.Collections;
 import java.util.List;
+import java.util.stream.Collectors;
 
 public class LargeCatItemResponse {
     private Long id;
@@ -28,6 +29,13 @@ public class LargeCatItemResponse {
 
     public LargeCatItemResponse withSmallCatItems(List<SmallCatItemPreviewResponse> smallCatItems) {
         this.smallCatItems = smallCatItems != null ? smallCatItems : Collections.emptyList();
+        return this;
+    }
+
+    public LargeCatItemResponse withAllSmallCatItems(List<SmallCatItemPreviewResponse> smallCatItems) {
+        this.smallCatItems = smallCatItems.stream()
+                .filter(item -> item.getLargeCatItemId().equals(this.id))
+                .collect(Collectors.toList());
         return this;
     }
 

--- a/src/main/resources/mapper/SmallCatMapper.xml
+++ b/src/main/resources/mapper/SmallCatMapper.xml
@@ -14,6 +14,18 @@
          WHERE checklist.id = #{checklistId}
            AND large.id = #{largeCatItemId}
            AND small.is_deleted = false
+      ORDER BY small.large_category_item_id, small.sequence ASC;
+    </select>
+
+    <select id="findItemPreviewsByChecklistId" resultType="org.swyp.weddy.domain.checklist.entity.SmallCatItemPreview">
+        SELECT small.id, small.large_category_item_id, small.title, small.due_date, assignee.name, status.name "status_name", small.amount
+          FROM small_category_item small
+          JOIN large_category_item large ON small.large_category_item_id = large.id
+          JOIN checklist ON large.checklist_id = checklist.id
+          LEFT JOIN small_category_item_assignee assignee ON small.assignee_id = assignee.id
+          LEFT JOIN small_category_item_status status ON small.status_id = status.id
+         WHERE checklist.id = #{checklistId}
+           AND small.is_deleted = false
       ORDER BY small.sequence ASC;
     </select>
 

--- a/src/main/resources/sql/schema.sql
+++ b/src/main/resources/sql/schema.sql
@@ -74,3 +74,8 @@ ALTER TABLE `small_category_item`
 
 ALTER TABLE `small_category_item`
     ADD FOREIGN KEY (`assignee_id`) REFERENCES `small_category_item_assignee` (`id`);
+
+-- 인덱스 추가
+CREATE INDEX idx_checklist_del_seq ON large_category_item(checklist_id, is_deleted, sequence);
+
+CREATE INDEX idx_large_del_seq ON small_category_item(large_category_item_id, is_deleted, sequence);

--- a/src/main/resources/sql/schema.sql
+++ b/src/main/resources/sql/schema.sql
@@ -74,3 +74,5 @@ ALTER TABLE `small_category_item`
 
 ALTER TABLE `small_category_item`
     ADD FOREIGN KEY (`assignee_id`) REFERENCES `small_category_item_assignee` (`id`);
+
+CREATE index idx_oauth_id ON member(oauth_id);

--- a/src/main/resources/sql/schema.sql
+++ b/src/main/resources/sql/schema.sql
@@ -74,8 +74,3 @@ ALTER TABLE `small_category_item`
 
 ALTER TABLE `small_category_item`
     ADD FOREIGN KEY (`assignee_id`) REFERENCES `small_category_item_assignee` (`id`);
-
--- 인덱스 추가
-CREATE INDEX idx_checklist_del_seq ON large_category_item(checklist_id, is_deleted, sequence);
-
-CREATE INDEX idx_large_del_seq ON small_category_item(large_category_item_id, is_deleted, sequence);

--- a/src/test/java/org/swyp/weddy/domain/checklist/service/FilteringServiceTest.java
+++ b/src/test/java/org/swyp/weddy/domain/checklist/service/FilteringServiceTest.java
@@ -147,6 +147,11 @@ class FilteringServiceTest {
         }
 
         @Override
+        public List<SmallCatItemPreviewResponse> findItemPreviewsByChecklistId(Long checklistId) {
+            return List.of();
+        }
+
+        @Override
         public SmallCatItemResponse findItem(Long checklistId, Long largeCatItemId, Long smallCatItemId) {
             return null;
         }

--- a/src/test/java/org/swyp/weddy/domain/checklist/service/LargeCatServiceTest.java
+++ b/src/test/java/org/swyp/weddy/domain/checklist/service/LargeCatServiceTest.java
@@ -206,6 +206,11 @@ class LargeCatServiceTest {
         }
 
         @Override
+        public List<SmallCatItemPreviewResponse> findItemPreviewsByChecklistId(Long checklistId) {
+            return List.of();
+        }
+
+        @Override
         public SmallCatItemResponse findItem(Long checklistId, Long largeCatItemId, Long smallCatItemId) {
             return null;
         }


### PR DESCRIPTION
https://github.com/your-weddy/back/issues/102

@rogarithm 
세훈님, 대분류항목 API를 좀 손봤습니다.
세훈님 쪽 로직이라, 변경한거 말씀드려요. 피드백은 안주셔도 괜찮습니다.

대량 트래픽이 있는 시스템이라 가정하고 DB쪽 최적화를 해봤습니다.

대분류 GET API에서 
- 현재: 현재 대분류 항목 갯수만큼 쿼리가 돌고 있는데요
- 수정: 쿼리1번으로 소분류 preview들 한 번에 가져오도록 변경했습니다.

그리고, 멤버쪽 인덱스 추가했습니다.

관련 자세한 내용은 위의 #102 번 참고부탁드려요.