### PR TITLE
도커를 사용한 CD 파이프라인 구축

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -1,133 +1,46 @@
-#name: Deploy to EC2
-#
-#on:
-#  push:
-#    branches:
-#      - main
-#
-#jobs:
-#  deploy:
-#    runs-on: ubuntu-latest
-#    steps:
-#      - name: Checkout code
-#        uses: actions/checkout@v4
-#
-#      - name: Set up JDK 21
-#        uses: actions/setup-java@v4
-#        with:
-#          java-version: '21'
-#          distribution: 'temurin'
-#
-#      - name: Build with Gradle
-#        run: ./gradlew clean build
-#
-#      - name: Prepare SSH Key
-#        env:
-#          EC2_KEY: ${{ secrets.EC2_KEY }}
-#        run: |
-#          echo "$EC2_KEY" > weddy-key.pem
-#          chmod 400 weddy-key.pem
-#
-#      - name: Copy JAR to EC2
-#        env:
-#          EC2_HOST: ${{ secrets.EC2_HOST }}
-#          EC2_USER: ${{ secrets.EC2_USER }}
-#        run: |
-#          ssh -i weddy-key.pem -o StrictHostKeyChecking=no $EC2_USER@$EC2_HOST "rm -f /home/$EC2_USER/app/*.jar"
-#          echo "Starting rsync transfer..."
-#          rsync -avz --progress -e "ssh -i weddy-key.pem -o StrictHostKeyChecking=no" ./build/libs/weddy-0.0.1-SNAPSHOT.jar $EC2_USER@$EC2_HOST:/home/$EC2_USER/app/ || { echo "rsync failed"; exit 1; }
-#          echo "rsync completed"
-#
-#      - name: Deploy to EC2
-#        env:
-#          EC2_HOST: ${{ secrets.EC2_HOST }}
-#          EC2_USER: ${{ secrets.EC2_USER }}
-#          MYSQL_URL: ${{ secrets.MYSQL_URL }}
-#          MYSQL_PORT: ${{ secrets.MYSQL_PORT }}
-#          MYSQL_DBNAME: ${{ secrets.MYSQL_DBNAME }}
-#          MYSQL_USERNAME: ${{ secrets.MYSQL_USERNAME }}
-#          MYSQL_PASSWORD: ${{ secrets.MYSQL_PASSWORD }}
-#          JWT_SECRET: ${{ secrets.JWT_SECRET }}
-#          AUTHORIZE_URIS: ${{ secrets.AUTHORIZE_URIS }}
-#          CORS_URIS: ${{ secrets.CORS_URIS }}
-#          LOGIN_PAGE_URL: ${{ secrets.LOGIN_PAGE_URL }}
-#          HOME_PAGE_URL: ${{ secrets.HOME_PAGE_URL }}
-#          KAKAO_CLIENT_ID: ${{ secrets.KAKAO_CLIENT_ID }}
-#          KAKAO_REDIRECT_URL: ${{ secrets.KAKAO_REDIRECT_URL }}
-#          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-#          AWS_ACCESS_KEY_SECRET: ${{ secrets.AWS_ACCESS_KEY_SECRET }}
-#        run: |
-#          ssh -i weddy-key.pem -o StrictHostKeyChecking=no $EC2_USER@$EC2_HOST << EOF
-#
-#            # SDKMAN 환경 로드
-#            [ -s "/home/$EC2_USER/.sdkman/bin/sdkman-init.sh" ] && . "/home/$EC2_USER/.sdkman/bin/sdkman-init.sh"
-#
-#            cd /home/$EC2_USER/app
-#            echo "Checking for running Java processes..."
-#            PID=\$(pgrep -f 'java.*weddy.*jar')
-#
-#            if [ -n "\$PID" ]; then
-#              echo "Killing existing Java process: \$PID"
-#              kill -9 \$PID
-#              sleep 1
-#
-#              echo "Checking if application is killed..."
-#              MAX_WAIT=30
-#              INTERVAL=3
-#              ELAPSED=0
-#
-#              while [ \$ELAPSED -lt \$MAX_WAIT ]; do
-#                if pgrep -f 'java.*weddy.*jar' > /dev/null; then
-#                  echo "Waiting for process \$PID to terminate... (\$ELAPSED seconds elapsed)"
-#                  sleep \$INTERVAL
-#                  ELAPSED=$((ELAPSED + INTERVAL))
-#                else
-#                  echo "Process \$PID terminated successfully after \$ELAPSED seconds"
-#                  break
-#                fi
-#              done
-#
-#              if [ \$ELAPSED -ge \$MAX_WAIT ]; then
-#                echo "Error: Process \$PID did not terminate within \$MAX_WAIT seconds"
-#                exit 1
-#              fi
-#            else
-#              echo "No existing Java process found."
-#            fi
-#
-#            nohup java -Dspring.profiles.active=prod -jar weddy-0.0.1-SNAPSHOT.jar \
-#              --MYSQL_URL="$MYSQL_URL" \
-#              --MYSQL_PORT="$MYSQL_PORT" \
-#              --MYSQL_DBNAME="$MYSQL_DBNAME" \
-#              --MYSQL_USERNAME="$MYSQL_USERNAME" \
-#              --MYSQL_PASSWORD="$MYSQL_PASSWORD" \
-#              --JWT_SECRET="$JWT_SECRET" \
-#              --AUTHORIZE_URIS="$AUTHORIZE_URIS" \
-#              --CORS_URIS="$CORS_URIS" \
-#              --LOGIN_PAGE_URL="$LOGIN_PAGE_URL" \
-#              --HOME_PAGE_URL="$HOME_PAGE_URL" \
-#              --KAKAO_CLIENT_ID="$KAKAO_CLIENT_ID" \
-#              --KAKAO_REDIRECT_URL="$KAKAO_REDIRECT_URL" \
-#              --AWS_ACCESS_KEY_ID="$AWS_ACCESS_KEY_ID" \
-#              --AWS_ACCESS_KEY_SECRET="$AWS_ACCESS_KEY_SECRET" > /dev/null 2>&1 &
-#
-#
-#            echo "Checking if application starts..."
-#            MAX_WAIT=180
-#            INTERVAL=10
-#            ELAPSED=0
-#
-#            while [ \$ELAPSED -lt \$MAX_WAIT ]; do
-#              if pgrep -f 'java.*weddy.*jar' > /dev/null; then
-#                echo "Application started successfully after \$ELAPSED seconds"
-#                exit 0
-#              fi
-#              sleep \$INTERVAL
-#              ELAPSED=$((ELAPSED + INTERVAL))
-#              echo "Waited \$ELAPSED seconds..."
-#            done
-#
-#            echo "Application failed to start within 180 seconds"
-#            exit 1
-#
-#          EOF
+name: CD Pipeline
+
+on:
+  push:
+    branches:
+      - issue-110
+
+jobs:
+  build-and-deploy:
+    runs-on: ubuntu-latest
+
+    steps:
+      # 1. 리포지토리 체크아웃
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      # 2. AWS CLI 및 도커 설정
+      - name: Set up AWS CLI
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ap-northeast-2
+
+      # 3. ECR 로그인 (ECR)
+      - name: Login to Amazon ECR
+        run: aws ecr get-login-password --region ap-northeast-2 | docker login --username AWS --password-stdin ${{ secrets.ECR_REGISTRY }}
+
+      # 4. 도커 이미지 빌드 및 푸시
+      - name: Build and push Docker image
+        run: |
+          docker build -f Dockerfile-prod -t ${{ secrets.ECR_REGISTRY }}/weddy-server-docker:latest .
+          docker push ${{ secrets.ECR_REGISTRY }}/weddy-server-docker:latest
+
+      # 5. EC2에 SSH로 접속해 배포
+      - name: Deploy to EC2
+        uses: appleboy/ssh-action@v1.0.0
+        with:
+          host: ${{ secrets.EC2_HOST }}
+          username: ${{ secrets.EC2_USER }}
+          key: ${{ secrets.EC2_KEY }}
+          script: |
+            aws ecr get-login-password --region ap-northeast-2 | docker login --username AWS --password-stdin ${{ secrets.ECR_REGISTRY }}
+            docker pull ${{ secrets.ECR_REGISTRY }}/weddy-server-docker:latest
+            docker compose -f /home/ubuntu/weddy-docker/compose.yml down
+            docker compose -f /home/ubuntu/weddy-docker/compose.yml up -d

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -3,7 +3,7 @@ name: CD Pipeline
 on:
   push:
     branches:
-      - issue-110
+      - main
 
 jobs:
   build-and-deploy:


### PR DESCRIPTION
CD 파이프라인 입니다.
1. main브랜치에 머지 시 cd event 발생.
2. GithubActions에서 스프링 서버의 도커 이미지를 생성.
3. 생성된 이미지를 AWS ECR에 푸시(PUSH).
4. EC2에 접속하여 ECR에 있는 이미지를 풀(PULL).
5. EC2에서 도커 컴포즈 실행.

[도입 배경]
- 서비스에 도커를 도입함에 따라, CD 파이프라인을 재구축 함.
- 기존의 CD는 시간이 오래 걸림. GithubActions에서 jar파일을 생성 후, EC2에 전송해야 했음. 하지만 이 전송 시간이 약 6분 정도 걸렸고, 이를 줄일 필요가 있다고 느낌.

[기술 사용 이유]
- ECR을 사용하여 기존의 빌드파일 전송보다 속도를 높임.
- 도커 이미지를 경량화하여 이미지 전송 속도를 보다 높임.

[결과]
- 배포시간을 7분대 -> 1분대로  단축 
  - 기존 프로세스의 'jar파일을 EC2에 전송'단계를 'ECR로 도커 이미지를 푸시하고, EC2에서 풀' 로 바꿔 시간 단축.
![image](https://github.com/user-attachments/assets/027cfcf8-2441-4c50-994f-9852a7d9dc43)  
![image](https://github.com/user-attachments/assets/82787023-5c4c-44bf-846d-0a77d0a81514)
